### PR TITLE
Fix Travis CI build image link

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ What is "flow" in FastNetMon terms? It's one or multiple udp, tcp, icmp connecti
 
 License: GPLv2
 
-[![Build Status](https://travis-ci.org/pavel-odintsov/fastnetmon.svg?branch=master)](https://travis-ci.org/FastVPSEestiOu/fastnetmon) [![Gitter](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/FastVPSEestiOu/fastnetmon?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge) 
+[![Build Status](https://travis-ci.org/pavel-odintsov/fastnetmon.svg?branch=master)](https://travis-ci.org/pavel-odintsov/fastnetmon) [![Gitter](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/FastVPSEestiOu/fastnetmon?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge) 
 
 
 


### PR DESCRIPTION
The link of the build image is pointing to an obsoleted/freezed project.