### PR TITLE
Update fast_library.cpp

### DIFF
--- a/src/fast_library.cpp
+++ b/src/fast_library.cpp
@@ -841,7 +841,11 @@ direction get_packet_direction(patricia_tree_t* lookup_tree, uint32_t src_ip, ui
 
     subnet = 0;
     if (our_ip_is_source && our_ip_is_destination) {
-        packet_direction = INTERNAL;
+        subnet = source_subnet;
+        subnet_cidr_mask = source_subnet_cidr_mask;
+        
+        //packet_direction = INTERNAL;
+        packet_direction = INCOMING;
     } else if (our_ip_is_source) {
         subnet = source_subnet;
         subnet_cidr_mask = source_subnet_cidr_mask;


### PR DESCRIPTION
change direction INTERNAL direction to INCOMING for check INTERNAL packets.
This solution is best ignore support for INTERNAL traffic and I think for temporary solution is good idea.
