### PR TITLE
Поправлена часть скрипта остановки демона #gentoo

### DIFF
--- a/src/fastnetmon_init_script_gentoo
+++ b/src/fastnetmon_init_script_gentoo
@@ -22,10 +22,15 @@ start() {
 stop() {
     ebegin "Stopping fastnetmon"
 
-    kill -9 `cat $PIDFILE`
-    RETVAL=$?
-
-    pidof fastnetmon | xargs kill -9
+    if [ -f $PIDFILE ]; then
+    	kill -9 $(cat $PIDFILE) 2>/dev/null
+	RETVAL=$?
+    fi
+    if [ -n $RETVAL ] && [ "$RETVAL" -ne "0" ]; then
+    	ACTUAL_PID=$(pidof fastnetmon)
+	[ -n $ACTUAL_PID ] && kill -9 $ACTUAL_PID 2>/dev/null
+	RETVAL=$?
+    fi
 
     rm -f "${PIDFILE}"
     eend $RETVAL


### PR DESCRIPTION
Поправлена часть скрипта остановки демона #gentoo

При отсутствий процесса по пиду из файла, скрипт останавливался, отсюда и не работал restart демона.