### PR TITLE
Add next-hop in exabgp withdrawal

### DIFF
--- a/src/fastnetmon.cpp
+++ b/src/fastnetmon.cpp
@@ -2924,7 +2924,7 @@ void exabgp_prefix_ban_manage(std::string action, std::string prefix_as_string_w
         sprintf(bgp_message, "announce route %s next-hop %s community %s\n",
             prefix_as_string_with_mask.c_str(), exabgp_next_hop.c_str(), exabgp_community.c_str());
     } else {
-        sprintf(bgp_message, "withdraw route %s\n", prefix_as_string_with_mask.c_str());
+        sprintf(bgp_message, "withdraw route %s next-hop %s\n", prefix_as_string_with_mask.c_str(), exabgp_next_hop.c_str());
     }    
 
     logger << log4cpp::Priority::INFO << "ExaBGP announce message: " << bgp_message;


### PR DESCRIPTION
In order to withdraw an announced route in exabgp next-hop is needed as it could be more than one announcement for an specified prefix.