### PR TITLE
flow_spec announcement and NDPI packet inspection

### DIFF
--- a/src/bgp_flow_spec.h
+++ b/src/bgp_flow_spec.h
@@ -307,16 +307,18 @@ class exabgp_flow_spec_rule_t : public flow_spec_rule_t {
         // More details regarding format: https://github.com/Exa-Networks/exabgp/blob/master/qa/conf/api-flow.run
         // https://plus.google.com/+ThomasMangin/posts/bL6w16BXcJ4
         // This format is INCOMPATIBLE with ExaBGP v3, please be careful!
+        // v4 rule example:
+        // announce flow route { match { source 10.0.0.2/32; destination 10.0.0.3/32; destination-port =3128; protocol tcp; } then { rate-limit 9600; } }'
         std::string serialize_single_line_exabgp_v4_configuration() {
             this->enabled_indents = false;
-            this->enble_block_headers = false;
+            //this->enble_block_headers = false;
             sentence_separator = " "; 
 
             return "flow route " + this->serialize_match() + this->serialize_then(); 
 
             sentence_separator = ";";
             this->enabled_indents = true;
-            this->enble_block_headers = true; 
+            //this->enble_block_headers = true; 
         }
 
         std::string serialize_complete_exabgp_configuration() {

--- a/src/bgp_flow_spec.h
+++ b/src/bgp_flow_spec.h
@@ -309,7 +309,6 @@ class exabgp_flow_spec_rule_t : public flow_spec_rule_t {
         // This format is INCOMPATIBLE with ExaBGP v3, please be careful!
         // v4 rule example:
         // announce flow route { match { source 10.0.0.2/32; destination 10.0.0.3/32; destination-port =3128; protocol tcp; } then { rate-limit 9600; } }'
-        // announce flow route match {destination 1.2.3.4/32 protocol [ udp ] source-port [ =53 ] }then {discard }
         
         std::string serialize_single_line_exabgp_v4_configuration() {
             this->enabled_indents = false;

--- a/src/bgp_flow_spec.h
+++ b/src/bgp_flow_spec.h
@@ -309,14 +309,15 @@ class exabgp_flow_spec_rule_t : public flow_spec_rule_t {
         // This format is INCOMPATIBLE with ExaBGP v3, please be careful!
         // v4 rule example:
         // announce flow route { match { source 10.0.0.2/32; destination 10.0.0.3/32; destination-port =3128; protocol tcp; } then { rate-limit 9600; } }'
+        // announce flow route match {destination 1.2.3.4/32 protocol [ udp ] source-port [ =53 ] }then {discard }
+        
         std::string serialize_single_line_exabgp_v4_configuration() {
             this->enabled_indents = false;
-            //this->enble_block_headers = false;
-            sentence_separator = " "; 
 
-            return "flow route " + this->serialize_match() + this->serialize_then(); 
+            sentence_separator = ";"; 
 
-            sentence_separator = ";";
+            return "flow route {" + this->serialize_match() + this->serialize_then() + "}"; 
+
             this->enabled_indents = true;
             //this->enble_block_headers = true; 
         }
@@ -507,7 +508,7 @@ class exabgp_flow_spec_rule_t : public flow_spec_rule_t {
             }
             
             if (enble_block_headers) {
-                buffer << "then {";
+                buffer << " then {";
             }
 
             if (enabled_indents) {

--- a/src/fastnetmon.cpp
+++ b/src/fastnetmon.cpp
@@ -3621,10 +3621,7 @@ void produce_dpi_dump_for_pcap_dump(std::string pcap_file_path, std::stringstrea
 
     src = (struct ndpi_id_struct*)malloc(ndpi_size_id_struct);
     dst = (struct ndpi_id_struct*)malloc(ndpi_size_id_struct);
-
     flow = (struct ndpi_flow_struct *)malloc(ndpi_size_flow_struct); 
-    memset(flow, 0, ndpi_size_flow_struct);
-
 
     while (1) {
         struct fastnetmon_pcap_pkthdr pcap_packet_header;
@@ -3651,6 +3648,18 @@ void produce_dpi_dump_for_pcap_dump(std::string pcap_file_path, std::stringstrea
 
         memset(src, 0, ndpi_size_id_struct);
         memset(dst, 0, ndpi_size_id_struct);
+
+        // the flow must be reset to zero state - in other case the DPI will not detect all packets properly.
+        // To use flow properly there must be much more complicated code (with flow buffer for each flow probably)
+        // following code is copied from ndpi_free_flow() just to be sure there will be no memory leaks due to memset()
+        if (flow->http.url) {
+            ndpi_free(flow->http.url);
+        };
+        if (flow->http.content_type) {
+            ndpi_free(flow->http.content_type);
+        }
+        //
+        memset(flow, 0, ndpi_size_flow_struct);
 
         std::string parsed_packet_as_string;
 

--- a/src/fastnetmon.cpp
+++ b/src/fastnetmon.cpp
@@ -3621,7 +3621,9 @@ void produce_dpi_dump_for_pcap_dump(std::string pcap_file_path, std::stringstrea
 
     src = (struct ndpi_id_struct*)malloc(ndpi_size_id_struct);
     dst = (struct ndpi_id_struct*)malloc(ndpi_size_id_struct);
+
     flow = (struct ndpi_flow_struct *)malloc(ndpi_size_flow_struct); 
+    memset(flow, 0, ndpi_size_flow_struct);
 
     while (1) {
         struct fastnetmon_pcap_pkthdr pcap_packet_header;

--- a/src/fastnetmon.cpp
+++ b/src/fastnetmon.cpp
@@ -3701,11 +3701,6 @@ void produce_dpi_dump_for_pcap_dump(std::string pcap_file_path, std::stringstrea
     
     close(filedesc);
 
-//    amplification_attack_type_t attack_type;
-
-    // Attack type is unknown by default
-//    attack_type = AMPLIFICATION_ATTACK_UNKNOWN;
-
     logger << log4cpp::Priority::INFO 
            << "DPI pkt stats: total:"  << total_packets_number
                            << " DNS:"  << dns_amplification_packets

--- a/src/fastnetmon.cpp
+++ b/src/fastnetmon.cpp
@@ -3621,7 +3621,9 @@ void produce_dpi_dump_for_pcap_dump(std::string pcap_file_path, std::stringstrea
 
     src = (struct ndpi_id_struct*)malloc(ndpi_size_id_struct);
     dst = (struct ndpi_id_struct*)malloc(ndpi_size_id_struct);
+
     flow = (struct ndpi_flow_struct *)malloc(ndpi_size_flow_struct); 
+    memset(flow, 0, ndpi_size_flow_struct);
 
 
     while (1) {
@@ -3649,7 +3651,6 @@ void produce_dpi_dump_for_pcap_dump(std::string pcap_file_path, std::stringstrea
 
         memset(src, 0, ndpi_size_id_struct);
         memset(dst, 0, ndpi_size_id_struct);
-        memset(flow, 0, ndpi_size_flow_struct);
 
         std::string parsed_packet_as_string;
 
@@ -3694,27 +3695,24 @@ void produce_dpi_dump_for_pcap_dump(std::string pcap_file_path, std::stringstrea
     // Attack type is unknown by default
 //    attack_type = AMPLIFICATION_ATTACK_UNKNOWN;
 
-    char buff[256];
-                                          
-    snprintf(&buff[0],sizeof(buff)-1,"DPI pkt stats: total:%llu DNS:%llu NTP:%llu SSDP:%llu SNMP:%llu",
-                                                  total_packets_number,
-                                                  dns_amplification_packets,
-                                                  ntp_amplification_packets,
-                                                  ssdp_amplification_packets,
-                                                  snmp_amplification_packets);
-    logger << log4cpp::Priority::INFO << buff;
+    logger << log4cpp::Priority::INFO 
+           << "DPI pkt stats: total:"  << total_packets_number
+                           << " DNS:"  << dns_amplification_packets
+                           << " NTP:"  << ntp_amplification_packets
+                           << " SSDP:" << ssdp_amplification_packets
+                           << " SNMP:" << snmp_amplification_packets;
                                        
     // Detect amplification attack type
-    if ( (double)dns_amplification_packets / (double)total_packets_number > 0.1) {
+    if ( (double)dns_amplification_packets / (double)total_packets_number > 0.2) {
 //        attack_type = AMPLIFICATION_ATTACK_DNS;
         launch_bgp_flow_spec_rule(AMPLIFICATION_ATTACK_DNS, client_ip_as_string);        
-    } else if ( (double)ntp_amplification_packets / (double)total_packets_number > 0.1) {
+    } else if ( (double)ntp_amplification_packets / (double)total_packets_number > 0.2) {
 //        attack_type = AMPLIFICATION_ATTACK_NTP;
         launch_bgp_flow_spec_rule(AMPLIFICATION_ATTACK_NTP, client_ip_as_string);        
-    } else if ( (double)ssdp_amplification_packets / (double)total_packets_number > 0.1) {
+    } else if ( (double)ssdp_amplification_packets / (double)total_packets_number > 0.2) {
 //        attack_type = AMPLIFICATION_ATTACK_SSDP;
         launch_bgp_flow_spec_rule(AMPLIFICATION_ATTACK_SSDP, client_ip_as_string);        
-    } else if ( (double)snmp_amplification_packets / (double)total_packets_number > 0.1) {
+    } else if ( (double)snmp_amplification_packets / (double)total_packets_number > 0.2) {
 //        attack_type = AMPLIFICATION_ATTACK_SNMP;
         launch_bgp_flow_spec_rule(AMPLIFICATION_ATTACK_SNMP, client_ip_as_string);        
     } else {

--- a/src/fastnetmon.cpp
+++ b/src/fastnetmon.cpp
@@ -3552,6 +3552,34 @@ void init_current_instance_of_ndpi() {
     ndpi_size_flow_struct = ndpi_detection_get_sizeof_ndpi_flow_struct(); 
 }
 
+void launch_bgp_flow_spec_rule(amplification_attack_type_t attack_type, std::string client_ip_as_string) {
+    logger << log4cpp::Priority::INFO << "We detected this attack as: " << get_amplification_attack_type(attack_type);
+
+    std::string flow_spec_rule_text = generate_flow_spec_for_amplification_attack(attack_type, client_ip_as_string);
+
+    logger << log4cpp::Priority::INFO << "We have generated BGP Flow Spec rule for this attack: " << flow_spec_rule_text;
+
+    if (exabgp_flow_spec_announces) {
+        active_flow_spec_announces_t::iterator itr = active_flow_spec_announces.find(flow_spec_rule_text);
+
+        if (itr == active_flow_spec_announces.end()) {
+            // We havent this flow spec rule active yet
+
+            logger << log4cpp::Priority::INFO << "We will publish flow spec announce about this attack";
+            bool exabgp_publish_result = exabgp_flow_spec_ban_manage("ban", flow_spec_rule_text);
+
+            if (exabgp_publish_result) {
+                active_flow_spec_announces[ flow_spec_rule_text ] = 1;
+            }
+        } else {
+            // We have already blocked this attack
+            logger << log4cpp::Priority::INFO << "The same rule was aready sent to ExaBGP formerly";
+        }
+    } else {
+          logger << log4cpp::Priority::INFO << "exabgp_flow_spec_announces disabled. We will not talk to ExaBGP";
+    }
+}
+
 // Not so pretty copy and paste from pcap_reader()
 // TODO: rewrite to memory parser
 void produce_dpi_dump_for_pcap_dump(std::string pcap_file_path, std::stringstream& ss, std::string client_ip_as_string) {
@@ -3661,10 +3689,10 @@ void produce_dpi_dump_for_pcap_dump(std::string pcap_file_path, std::stringstrea
     
     close(filedesc);
 
-    amplification_attack_type_t attack_type;
+//    amplification_attack_type_t attack_type;
 
-    // Attack type in unknown by default
-    attack_type = AMPLIFICATION_ATTACK_UNKNOWN;
+    // Attack type is unknown by default
+//    attack_type = AMPLIFICATION_ATTACK_UNKNOWN;
 
     char buff[256];
                                           
@@ -3677,41 +3705,25 @@ void produce_dpi_dump_for_pcap_dump(std::string pcap_file_path, std::stringstrea
     logger << log4cpp::Priority::INFO << buff;
                                        
     // Detect amplification attack type
-    if ( (double)dns_amplification_packets / (double)total_packets_number > 0.5) {
-        attack_type = AMPLIFICATION_ATTACK_DNS;
-    } else if ( (double)ntp_amplification_packets / (double)total_packets_number > 0.5) {
-        attack_type = AMPLIFICATION_ATTACK_NTP;
-    } else if ( (double)ssdp_amplification_packets / (double)total_packets_number > 0.5) {
-        attack_type = AMPLIFICATION_ATTACK_SSDP;
-    } else if ( (double)snmp_amplification_packets / (double)total_packets_number > 0.5) {
-        attack_type = AMPLIFICATION_ATTACK_SNMP;
-    }
-
-    if (attack_type == AMPLIFICATION_ATTACK_UNKNOWN) {
-        logger << log4cpp::Priority::ERROR << "We can't detect attack type with DPI it's not so criticial, only for your information";
+    if ( (double)dns_amplification_packets / (double)total_packets_number > 0.1) {
+//        attack_type = AMPLIFICATION_ATTACK_DNS;
+        launch_bgp_flow_spec_rule(AMPLIFICATION_ATTACK_DNS, client_ip_as_string);        
+    } else if ( (double)ntp_amplification_packets / (double)total_packets_number > 0.1) {
+//        attack_type = AMPLIFICATION_ATTACK_NTP;
+        launch_bgp_flow_spec_rule(AMPLIFICATION_ATTACK_NTP, client_ip_as_string);        
+    } else if ( (double)ssdp_amplification_packets / (double)total_packets_number > 0.1) {
+//        attack_type = AMPLIFICATION_ATTACK_SSDP;
+        launch_bgp_flow_spec_rule(AMPLIFICATION_ATTACK_SSDP, client_ip_as_string);        
+    } else if ( (double)snmp_amplification_packets / (double)total_packets_number > 0.1) {
+//        attack_type = AMPLIFICATION_ATTACK_SNMP;
+        launch_bgp_flow_spec_rule(AMPLIFICATION_ATTACK_SNMP, client_ip_as_string);        
     } else {
-        logger << log4cpp::Priority::INFO << "We detected this attack as: " << get_amplification_attack_type(attack_type);
-    
-        std::string flow_spec_rule_text = generate_flow_spec_for_amplification_attack(attack_type, client_ip_as_string);
-
-        logger << log4cpp::Priority::INFO << "We have generated BGP Flow Spec rule for this attack: " << flow_spec_rule_text;
-
-        if (exabgp_flow_spec_announces) {
-            active_flow_spec_announces_t::iterator itr = active_flow_spec_announces.find(flow_spec_rule_text);
-
-            if (itr == active_flow_spec_announces.end()) {
-                // We havent this flow spec rule active yet
-
-                logger << log4cpp::Priority::INFO << "We will publish flow spec announce about this attack";
-                bool exabgp_publish_result = exabgp_flow_spec_ban_manage("ban", flow_spec_rule_text);
-
-                if (exabgp_publish_result) {
-                    active_flow_spec_announces[ flow_spec_rule_text ] = 1;
-                }
-            } else {
-                // We have already blocked this attack
-            }
-        }
+        logger << log4cpp::Priority::ERROR << "We can't detect attack type with DPI it's not so critical, only for your information";
+        
+/*TODO 
+  - full IP ban should be announced here !        
+  - and maybe some protocol/port based statistics could be used to filter new/unknown attacks...
+*/
     }
 }
 


### PR DESCRIPTION
Hi,

I have identified and solved bugs related to:
- ExaBGP v4 announcement (the code producing match{} etc code was commented out )
- inspection of captured DDoS attack packets - the file was closed after the first packet was processed. So the attack classification depended only on the first packet in the dump

Note: I am new to github pull requests and C++ to ...
