### PR TITLE
add RFC7999 BGP Blackhole community (65535:666) to routes added to mikrotik

### DIFF
--- a/src/mikrotik_plugin/fastnetmon_mikrotik.php
+++ b/src/mikrotik_plugin/fastnetmon_mikrotik.php
@@ -69,6 +69,7 @@ if ( $API->connect( $cfg[ ip_mikrotik ], $cfg[ api_user ], $cfg[ api_pass ] ) ) 
         $API->write( '/ip/route/add', false );
         $API->write( '=dst-address=' . $IP_ATTACK, false );
         $API->write( '=type=blackhole', false );
+        $API->write( '=bgp-communities=65535:666', false );
         $API->write( '=comment=' . $comment_rule );
         $ret = $API->read();
 


### PR DESCRIPTION
This tags routes added with 65535:666 which is the RFC7999 well-known BGP Blackhole community.