### PR TITLE
Restart Fastnetmon when it fails

### DIFF
--- a/src/fastnetmon.service
+++ b/src/fastnetmon.service
@@ -6,6 +6,8 @@ After=syslog.target network.target remote-fs.target
 Type=forking
 ExecStart=/opt/fastnetmon/fastnetmon --daemonize
 PIDFile=/run/fastnetmon.pid
+Restart=on-failure
+RestartSec=3
 
 #ExecReload=/bin/kill -s HUP $MAINPID
 #ExecStop=/bin/kill -s QUIT $MAINPID


### PR DESCRIPTION
Sometimes FastNetMon crashes due to Segfaults and to prevent an outage of the DDoS Sensor we should immediately restart it.