### PR TITLE
Track ExaBGP PID and quit tail when it dies

### DIFF
--- a/docs/EXABGP_INTEGRATION_WITHOUT_SOCAT.md
+++ b/docs/EXABGP_INTEGRATION_WITHOUT_SOCAT.md
@@ -33,12 +33,13 @@ For PIPE API we need create this script: ```vim /etc/exabgp/exabgp_pipe_provider
 Script code here:
 ```bash
 
-```#!/bin/sh
+#!/bin/sh
 FIFO="/var/run/exabgp.cmd"
+EXABGP_PID="`cat /var/run/exabgp.pid`"
 
 rm -f $FIFO
 mkfifo $FIFO
-tail -f $FIFO
+tail -f $FIFO --pid=$EXABGP_PID
 ```
 
 Set exec flag for script: ```chmod +x /etc/exabgp/exabgp_pipe_provider.sh```


### PR DESCRIPTION
From tail's man:

```
       --pid=PID
              with -f, terminate after process ID, PID dies
```

This is useful to exit from tail after ExaBGP shutdown.