### PR TITLE
Support setting ENABLE_LUA_SUPPORT

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -229,7 +229,7 @@ endif()
 # We do not enable it by default, it's testing feature
 # If you want it please build with:
 # cmake -DENABLE_LUA_SUPPORT=ON .. 
-set(ENABLE_LUA_SUPPORT yes)
+set(ENABLE_LUA_SUPPORT yes CACHE BOOL "Enable Lua support")
 if (ENABLE_LUA_SUPPORT)
     message(STATUS "We will enable LuaJIT support")
 


### PR DESCRIPTION
To allow users to disable Lua support, do not overwrite the ENABLE_LUA_SUPPORT variable. Instead just set the default if it is not set yet.