### PR TITLE
Support nDPI 2.1

### DIFF
--- a/src/fast_dpi.cpp
+++ b/src/fast_dpi.cpp
@@ -35,7 +35,11 @@ struct ndpi_detection_module_struct* init_ndpi() {
     u_int32_t detection_tick_resolution = 1000;
     
     struct ndpi_detection_module_struct* my_ndpi_struct =
+#if NDPI_MAJOR >= 2
+        ndpi_init_detection_module();
+#else
         ndpi_init_detection_module(detection_tick_resolution, malloc, free, debug_printf);
+#endif
 
     if (my_ndpi_struct == NULL) {
         // printf("Can't init nDPI");


### PR DESCRIPTION
The parameters to `ndpi_init_detection_module()` were changed in nDPI 1.8, but only nDPI 2.1 gained support for `NDPI_MAJOR` header variables. Therefore the preprocessor check works for new versions of nDPI, but not for nDPI between 1.8 and 2.0. This is the best we can get. Fixes more or less #597.