### PR TITLE
Link against atomic if __atomic_add_fetch_8 is missing

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -21,6 +21,9 @@ project(FastNetMon)
 # Get convinient paths for all system folders: http://www.cmake.org/gitweb?p=cmake.git;a=commitdiff;h=a262fe09
 # include(GNUInstallDirs)
 
+include(CheckCXXCompilerFlag)
+include(CheckLibraryExists)
+
 # Enable it and fix all warnigns!
 # add_definitions ("-Wall")
 
@@ -103,6 +106,22 @@ if (USE_NEW_ATOMIC_BUILTINS)
     message(STATUS "Will use new memory model aware atomic builtins")
     add_definitions(-DUSE_NEW_ATOMIC_BUILTINS) 
 endif() 
+
+CHECK_CXX_SOURCE_COMPILES("
+#include <cstdint>
+int main() {
+    uint64_t x = 1;
+    __atomic_add_fetch(&x, 0, __ATOMIC_RELAXED);
+    return x;
+}
+" HAVE__ATOMIC_ADD_FETCH)
+
+if (NOT HAVE__ATOMIC_ADD_FETCH)
+    check_library_exists(atomic __atomic_add_fetch_8 "" HAVE_LIBATOMIC)
+    if (HAVE_LIBATOMIC)
+        target_link_libraries(fastnetmon atomic)
+    endif()
+endif()
 
 # With this flag we can disable PF_RING build via console: cmake .. -DDISABLE_PF_RING_SUPPORT=ON
 if (NOT DISABLE_PF_RING_SUPPORT) 


### PR DESCRIPTION
src/fastnetmon.cpp uses __atomic_add_fetch(). Some architectures (like mips, mipsel, m68k, powerpc, sh4) do not provide these built-in functions and need to link against atomic to provide this function.

closes #703
Bug-Debian: https://bugs.debian.org/869805