### PR TITLE
add support for OpenBSD

### DIFF
--- a/src/fastnetmon.cpp
+++ b/src/fastnetmon.cpp
@@ -19,6 +19,7 @@
 #include <netinet/tcp.h>
 #include <netinet/udp.h>
 #include <netinet/ip_icmp.h>
+#include <net/if_arp.h> // struct arphdr
 #include <netinet/if_ether.h>
 #include <netinet/in.h>
 

--- a/src/fastnetmon_packet_parser.c
+++ b/src/fastnetmon_packet_parser.c
@@ -7,12 +7,14 @@
 #include <stdint.h>
 #include <stdlib.h>
 #include <netinet/in.h> // in6_addr
+#ifndef __OpenBSD__
 #include <net/ethernet.h>
+#endif
 #include <string.h> // memcpy
 #include <stdio.h>
 #include <arpa/inet.h> // inet_ntop
 
-#if defined(__FreeBSD__) || defined(__APPLE__) || defined(__DragonFly__)
+#if defined(__FreeBSD__) || defined(__APPLE__) || defined(__DragonFly__) || defined(__OpenBSD__)
 #include <sys/socket.h> // AF_INET6
 #endif
 
@@ -191,7 +193,7 @@ char* _intoa(unsigned int addr, char* buf, u_short bufLen);
 static char* in6toa(struct in6_addr addr6);
 char* proto2str(u_short proto);
 
-#if defined(__FreeBSD__) || defined(__APPLE__) || defined(__DragonFly__)
+#if defined(__FreeBSD__) || defined(__APPLE__) || defined(__DragonFly__) || defined(__OpenBSD__)
 /* This code from /usr/includes/linux/if_ether.h Linus file */
 #define ETH_ALEN 6 /* Octets in one ethernet addr   */
 #define ETH_P_IP 0x0800 /* Internet Protocol packet     */
@@ -210,7 +212,7 @@ struct ethhdr {
 
 #endif
 
-#if defined(__FreeBSD__) || defined(__APPLE__)
+#if defined(__FreeBSD__) || defined(__APPLE__) || defined(__OpenBSD__)
 u_int32_t pfring_hash_pkt(struct pfring_pkthdr* hdr) {
     if (hdr->extended_hdr.parsed_pkt.tunnel.tunnel_id == NO_TUNNEL_ID) {
         return hdr->extended_hdr.parsed_pkt.vlan_id + hdr->extended_hdr.parsed_pkt.l3_proto +

--- a/src/fastnetmon_packet_parser.h
+++ b/src/fastnetmon_packet_parser.h
@@ -4,7 +4,7 @@
 #include <sys/types.h>
 #include <netinet/in.h> // in6_addr
 
-#if defined(__APPLE__)
+#if defined(__APPLE__) || defined(__OpenBSD__)
 // For Mac OS X here we can find definition of "struct timeval"
 #include <sys/time.h>
 #endif

--- a/src/pcap_plugin/pcap_collector.cpp
+++ b/src/pcap_plugin/pcap_collector.cpp
@@ -11,6 +11,7 @@
 #include <string>
 
 #include <pcap.h>
+#include <net/if_arp.h> // struct arphdr
 #include <netinet/if_ether.h>
 #include <netinet/ip.h>
 #include <netinet/tcp.h>
@@ -121,13 +122,13 @@ void parse_packet(u_char* user, struct pcap_pkthdr* packethdr, const u_char* pac
     case IPPROTO_TCP:
         tcphdr = (struct tcphdr*)packetptr;
 
-#if defined(__FreeBSD__) || defined(__APPLE__) || defined(__DragonFly__)
+#if defined(__FreeBSD__) || defined(__APPLE__) || defined(__DragonFly__) || defined(__OpenBSD__)
         current_packet.source_port = ntohs(tcphdr->th_sport);
 #else
         current_packet.source_port = ntohs(tcphdr->source);
 #endif
 
-#if defined(__FreeBSD__) || defined(__APPLE__) || defined(__DragonFly__)
+#if defined(__FreeBSD__) || defined(__APPLE__) || defined(__DragonFly__) || defined(__OpenBSD__)
         current_packet.destination_port = ntohs(tcphdr->th_dport);
 #else
         current_packet.destination_port = ntohs(tcphdr->dest);
@@ -136,13 +137,13 @@ void parse_packet(u_char* user, struct pcap_pkthdr* packethdr, const u_char* pac
     case IPPROTO_UDP:
         udphdr = (struct udphdr*)packetptr;
 
-#if defined(__FreeBSD__) || defined(__APPLE__) || defined(__DragonFly__)
+#if defined(__FreeBSD__) || defined(__APPLE__) || defined(__DragonFly__) || defined(__OpenBSD__)
         current_packet.source_port = ntohs(udphdr->uh_sport);
 #else
         current_packet.source_port = ntohs(udphdr->source);
 #endif
 
-#if defined(__FreeBSD__) || defined(__APPLE__) || defined(__DragonFly__)
+#if defined(__FreeBSD__) || defined(__APPLE__) || defined(__DragonFly__) || defined(__OpenBSD__)
         current_packet.destination_port = ntohs(udphdr->uh_dport);
 #else
         current_packet.destination_port = ntohs(udphdr->dest);


### PR DESCRIPTION
This (and one additional change which may get addressed in OpenBSD itself) allow fastnetmon to work on OpenBSD. It was tested using NetFlow exports from pf via pflow.