### PR TITLE
Skipp non-protable CPU affinity code on non-GNU libc platforms

### DIFF
--- a/src/afpacket_plugin/afpacket_collector.cpp
+++ b/src/afpacket_plugin/afpacket_collector.cpp
@@ -324,7 +324,7 @@ void start_afpacket_collection(process_packet_pointer func_ptr) {
         for (int cpu = 0; cpu < num_cpus; cpu++) {
 
 // Well, we have thread attributes from Boost 1.50
-#if defined(BOOST_THREAD_PLATFORM_PTHREAD) && BOOST_VERSION / 100 % 1000 >= 50
+#if defined(BOOST_THREAD_PLATFORM_PTHREAD) && BOOST_VERSION / 100 % 1000 >= 50 && defined(__GLIBC__)
             boost::thread::attributes thread_attrs;
 
             if (afpacket_execute_strict_cpu_affinity) {

--- a/src/netmap_plugin/netmap_collector.cpp
+++ b/src/netmap_plugin/netmap_collector.cpp
@@ -214,7 +214,7 @@ void receiver(std::string interface_for_listening) {
 
 // Well, we have thread attributes from Boost 1.50
 
-#if defined(BOOST_THREAD_PLATFORM_PTHREAD) && BOOST_VERSION / 100 % 1000 >= 50 && !defined(__APPLE__)
+#if defined(BOOST_THREAD_PLATFORM_PTHREAD) && BOOST_VERSION / 100 % 1000 >= 50 && !defined(__APPLE__) && defined(__GLIBC__)
         /* Bind to certain core */
         boost::thread::attributes thread_attrs;
 


### PR DESCRIPTION
This is a small subset of the changes I proposed in a PR a few month ago. This change should be enough to compile with musl libc (/Alpine Linux).