### PR TITLE
Added decoding of the outer vlan tag in sflow packets.

### DIFF
--- a/src/fast_library.cpp
+++ b/src/fast_library.cpp
@@ -1284,3 +1284,7 @@ bool store_data_to_stats_server(unsigned short int graphite_port, std::string gr
         return false;
     }
 }
+
+uint32_t convert_hex_as_string_to_uint(std::string hex) {
+    return std::strtoul(hex.c_str(), 0, 16);
+}

--- a/src/fast_library.h
+++ b/src/fast_library.h
@@ -53,6 +53,7 @@ std::string convert_int_to_string(int value);
 std::string print_ipv6_address(struct in6_addr& ipv6_address);
 std::string print_simple_packet(simple_packet packet);
 std::string convert_timeval_to_date(struct timeval tv);
+uint32_t convert_hex_as_string_to_uint(std::string hex);
 
 int extract_bit_value(uint8_t num, int bit);
 int extract_bit_value(uint16_t num, int bit);

--- a/src/fastnetmon.conf
+++ b/src/fastnetmon.conf
@@ -165,6 +165,9 @@ sflow_host = 0.0.0.0
 # This option is not default and you need build it additionally
 # sflow_lua_hooks_path = /usr/src/fastnetmon/src/sflow_hooks.lua
 
+# sFLOW ethertype of outer tag in QinQ
+sflow_qinq_ethertype = 0x8100
+
 ###
 ### Actions when attack detected
 ###

--- a/src/sflow_hooks.lua
+++ b/src/sflow_hooks.lua
@@ -123,7 +123,8 @@ typedef struct _SFSample {
     uint8_t eth_dst[8];
 
     /* vlan */
-    uint32_t in_vlan;
+    uint32_t in_svlan;
+    uint32_t in_cvlan;
     uint32_t in_priority;
     uint32_t internalPriority;
     uint32_t out_vlan;

--- a/src/sflow_plugin/sflow_data.h
+++ b/src/sflow_plugin/sflow_data.h
@@ -151,7 +151,8 @@ typedef struct _SFSample {
     uint8_t eth_dst[8];
 
     /* vlan */
-    uint32_t in_vlan;
+    uint32_t in_svlan;
+    uint32_t in_cvlan;
     uint32_t in_priority;
     uint32_t internalPriority;
     uint32_t out_vlan;


### PR DESCRIPTION
Double vlan tagging can now decoded in sFLOW.

In fastnetmon.conf the outer ethertype tag can be configured for this packets. This variable is named **sflow_qinq_ethertype** and equal 0x8100 by default.