### PR TITLE
Added decoding of the outer vlan tag in sflow packets.

### DIFF
--- a/src/fast_library.cpp
+++ b/src/fast_library.cpp
@@ -1285,6 +1285,11 @@ bool store_data_to_stats_server(unsigned short int graphite_port, std::string gr
     }
 }
 
-uint32_t convert_hex_as_string_to_uint(std::string hex) {
-    return std::strtoul(hex.c_str(), 0, 16);
+bool convert_hex_as_string_to_uint(std::string hex, uint32_t& value) {
+    std::stringstream ss;
+
+    ss << std::hex << hex;
+    ss >> value;
+
+    return ss.fail();
 }

--- a/src/fast_library.cpp
+++ b/src/fast_library.cpp
@@ -1284,3 +1284,7 @@ bool store_data_to_stats_server(unsigned short int graphite_port, std::string gr
         return false;
     }
 }
+
+uint32_t convert_hex_as_string_to_uint(std::string hex) {
+    return std::strtoul(hex.c_str(), 0, 16);
+}

--- a/src/fast_library.h
+++ b/src/fast_library.h
@@ -53,7 +53,7 @@ std::string convert_int_to_string(int value);
 std::string print_ipv6_address(struct in6_addr& ipv6_address);
 std::string print_simple_packet(simple_packet packet);
 std::string convert_timeval_to_date(struct timeval tv);
-uint32_t convert_hex_as_string_to_uint(std::string hex);
+bool convert_hex_as_string_to_uint(std::string hex, uint32_t& value);
 
 int extract_bit_value(uint8_t num, int bit);
 int extract_bit_value(uint16_t num, int bit);

--- a/src/fast_library.h
+++ b/src/fast_library.h
@@ -53,6 +53,7 @@ std::string convert_int_to_string(int value);
 std::string print_ipv6_address(struct in6_addr& ipv6_address);
 std::string print_simple_packet(simple_packet packet);
 std::string convert_timeval_to_date(struct timeval tv);
+uint32_t convert_hex_as_string_to_uint(std::string hex);
 
 int extract_bit_value(uint8_t num, int bit);
 int extract_bit_value(uint16_t num, int bit);

--- a/src/fastnetmon.conf
+++ b/src/fastnetmon.conf
@@ -165,6 +165,9 @@ sflow_host = 0.0.0.0
 # This option is not default and you need build it additionally
 # sflow_lua_hooks_path = /usr/src/fastnetmon/src/sflow_hooks.lua
 
+# sFLOW ethertype of outer tag in QinQ
+sflow_qinq_ethertype = 0x8100
+
 ###
 ### Actions when attack detected
 ###

--- a/src/fastnetmon.conf
+++ b/src/fastnetmon.conf
@@ -165,7 +165,10 @@ sflow_host = 0.0.0.0
 # This option is not default and you need build it additionally
 # sflow_lua_hooks_path = /usr/src/fastnetmon/src/sflow_hooks.lua
 
-# sFLOW ethertype of outer tag in QinQ
+# sFlow processing QinQ
+sflow_qinq_process = off
+
+# sFlow ethertype of outer tag in QinQ
 sflow_qinq_ethertype = 0x8100
 
 ###

--- a/src/sflow_hooks.lua
+++ b/src/sflow_hooks.lua
@@ -123,8 +123,8 @@ typedef struct _SFSample {
     uint8_t eth_dst[8];
 
     /* vlan */
-    uint32_t in_svlan;
-    uint32_t in_cvlan;
+    uint32_t in_outer_vlan;
+    uint32_t in_vlan;
     uint32_t in_priority;
     uint32_t internalPriority;
     uint32_t out_vlan;

--- a/src/sflow_hooks.lua
+++ b/src/sflow_hooks.lua
@@ -123,7 +123,8 @@ typedef struct _SFSample {
     uint8_t eth_dst[8];
 
     /* vlan */
-    uint32_t in_vlan;
+    uint32_t in_svlan;
+    uint32_t in_cvlan;
     uint32_t in_priority;
     uint32_t internalPriority;
     uint32_t out_vlan;

--- a/src/sflow_plugin/sflow_collector.cpp
+++ b/src/sflow_plugin/sflow_collector.cpp
@@ -42,7 +42,10 @@ std::string sflow_lua_hooks_path = "/usr/src/fastnetmon/src/sflow_hooks.lua";
 #endif
 
 // Ethertype of outer tag in QinQ
-uint16_t sflow_qinq_ethertype = 0x8100;
+uint32_t sflow_qinq_ethertype = 0x8100;
+
+// Disable QinQ processing by default
+bool sflow_qinq_process = false;
 
 // sFLOW v4 specification: http://www.sflow.org/rfc3176.txt
 
@@ -89,8 +92,22 @@ void start_sflow_collection(process_packet_pointer func_ptr) {
         interface_for_binding = configuration_map["sflow_host"];
     }
 
-    if (configuration_map.count("sflow_qinq_ethertype") != 0) {
-        sflow_qinq_ethertype = convert_hex_as_string_to_uint(configuration_map["sflow_qinq_ethertype"]);
+    if (configuration_map.count("sflow_qinq_process") != 0) {
+        if (configuration_map["sflow_qinq_process"] == "on") {
+
+            sflow_qinq_process = true;
+            logger << log4cpp::Priority::INFO << plugin_log_prefix << "qinq processing enabled";
+
+            if (configuration_map.count("sflow_qinq_ethertype") != 0) {
+                if (convert_hex_as_string_to_uint(configuration_map["sflow_qinq_ethertype"], sflow_qinq_ethertype)) {
+                    logger << log4cpp::Priority::WARN << plugin_log_prefix
+                           << "can't parse value in sflow_qinq_ethertype variable";
+                    logger << log4cpp::Priority::INFO << plugin_log_prefix
+                           << "disable qinq processing";
+                    sflow_qinq_process = false;
+                }
+            }
+        }
     }
 
 #ifdef ENABLE_LUA_HOOKS
@@ -542,20 +559,14 @@ void decode_link_layer(SFSample* sample) {
     type_len = (ptr[0] << 8) + ptr[1];
     ptr += 2;
 
-    if (type_len == sflow_qinq_ethertype && ((ptr[2] << 8) + ptr[3]) == 0x8100) {
+    if (sflow_qinq_process && type_len == sflow_qinq_ethertype && ((ptr[2] << 8) + ptr[3]) == 0x8100) {
         /* Outer VLAN tag - next two bytes */
         uint32_t vlanData = (ptr[0] << 8) + ptr[1];
         uint32_t vlan = vlanData & 0x0fff;
         uint32_t priority = vlanData >> 13;
         ptr += 2;
 
-        /*  _____________________________________ */
-        /* |   pri  | c |         vlan-id        | */
-        /*  ------------------------------------- */
-        /* [priority = 3bits] [Canonical Format Flag = 1bit] [vlan-id = 12 bits] */
-        // sf_log(sample,"decodedVLAN %u\n", vlan);
-        // sf_log(sample,"decodedPriority %u\n", priority);
-        sample->in_svlan = vlan;
+        sample->in_outer_vlan = vlan;
         /* now get the type_len again (next two bytes) */
         type_len = (ptr[0] << 8) + ptr[1];
         ptr += 2;
@@ -574,7 +585,7 @@ void decode_link_layer(SFSample* sample) {
         /* [priority = 3bits] [Canonical Format Flag = 1bit] [vlan-id = 12 bits] */
         // sf_log(sample,"decodedVLAN %u\n", vlan);
         // sf_log(sample,"decodedPriority %u\n", priority);
-        sample->in_cvlan = vlan;
+        sample->in_vlan = vlan;
         /* now get the type_len again (next two bytes) */
         type_len = (ptr[0] << 8) + ptr[1];
         ptr += 2;

--- a/src/sflow_plugin/sflow_data.h
+++ b/src/sflow_plugin/sflow_data.h
@@ -151,7 +151,8 @@ typedef struct _SFSample {
     uint8_t eth_dst[8];
 
     /* vlan */
-    uint32_t in_vlan;
+    uint32_t in_svlan;
+    uint32_t in_cvlan;
     uint32_t in_priority;
     uint32_t internalPriority;
     uint32_t out_vlan;

--- a/src/sflow_plugin/sflow_data.h
+++ b/src/sflow_plugin/sflow_data.h
@@ -151,8 +151,8 @@ typedef struct _SFSample {
     uint8_t eth_dst[8];
 
     /* vlan */
-    uint32_t in_svlan;
-    uint32_t in_cvlan;
+    uint32_t in_outer_vlan;
+    uint32_t in_vlan;
     uint32_t in_priority;
     uint32_t internalPriority;
     uint32_t out_vlan;


### PR DESCRIPTION
Double vlan tagging can now decoded in sFLOW.

In fastnetmon.conf the outer ethertype tag can be configured for this packets. This variable is named **sflow_qinq_ethertype** and equal 0x8100 by default.