### PR TITLE
Fixed #692. Caused by https://github.com/json-c/json-c/issues/379

### DIFF
--- a/src/fastnetmon_install.pl
+++ b/src/fastnetmon_install.pl
@@ -739,9 +739,11 @@ sub install_json_c {
     if ($os_type eq 'macosx' or $os_type eq 'freebsd') {
         exec_command("sed -i -e '355 s#^#//#' json_tokener.c");
         exec_command("sed -i -e '360 s#^#//#' json_tokener.c");
+		exec_command("sed -i -e '381 s/AM_CFLAGS =/AM_CFLAGS = -Wimplicit-fallthrough=0/ ' Makefile.in");
     } else { 
         exec_command("sed -i '355 s#^#//#' json_tokener.c");
         exec_command("sed -i '360 s#^#//#' json_tokener.c");
+		exec_command("sed -i '381 s/AM_CFLAGS =/AM_CFLAGS = -Wimplicit-fallthrough=0/ ' Makefile.in");
     }
 
     print "Build it\n";


### PR DESCRIPTION
Installation failed with following error:
```
CMake Error at CMakeLists.txt:471 (message):
We can't find json-c library! Can't build project
```
It was caused by compilation problem of `json-c` library. Fixed by adding `-Wimplicit-fallthrough=0` to `AM_CFLAGS` in `Makefile.in`