### PR TITLE
Remove string copy

### DIFF
--- a/src/fastnetmon.cpp
+++ b/src/fastnetmon.cpp
@@ -912,7 +912,7 @@ std::string draw_table(direction data_direction, bool do_redis_update, sort_type
             std::replace(client_ip_as_string.begin(),
             		client_ip_as_string.end(), '.', '_');
 
-            std::string graphite_current_prefix = graphite_prefix + ".hosts." + ip_as_string_with_dash_delimiters + "." + direction_as_string;
+            std::string graphite_current_prefix = graphite_prefix + ".hosts." + client_ip_as_string + "." + direction_as_string;
 
             if (print_average_traffic_counts) {
                 graphite_current_prefix = graphite_current_prefix + ".average";

--- a/src/fastnetmon.cpp
+++ b/src/fastnetmon.cpp
@@ -4380,9 +4380,7 @@ bool exceed_mbps_speed(uint64_t in_counter, uint64_t out_counter, unsigned int t
 // Return true when we should ban this IP
 bool we_should_ban_this_ip(map_element* average_speed_element, ban_settings_t current_ban_settings) {
     // we detect overspeed by packets
-    bool attack_detected_by_pps = false;
-    bool attack_detected_by_bandwidth = false;
-    bool attack_detected_by_flow = false;
+
     if (current_ban_settings.enable_ban_for_pps &&
         exceed_pps_speed(average_speed_element->in_packets, average_speed_element->out_packets, current_ban_settings.ban_threshold_pps)) {
         logger << log4cpp::Priority::DEBUG  << "We detected this attack by pps limit";

--- a/src/fastnetmon.cpp
+++ b/src/fastnetmon.cpp
@@ -907,10 +907,10 @@ std::string draw_table(direction data_direction, bool do_redis_update, sort_type
                 direction_as_string = "outgoing";
             }
 
-            std::string ip_as_string_with_dash_delimiters = client_ip_as_string;
+
             // Replace dots by dashes
-            std::replace(ip_as_string_with_dash_delimiters.begin(),
-                ip_as_string_with_dash_delimiters.end(), '.', '_');
+            std::replace(client_ip_as_string.begin(),
+            		client_ip_as_string.end(), '.', '_');
 
             std::string graphite_current_prefix = graphite_prefix + ".hosts." + ip_as_string_with_dash_delimiters + "." + direction_as_string;
 
@@ -4133,21 +4133,21 @@ std::string print_subnet_load() {
             << subnet_as_string;
            
         if (graphite_enabled) {
-            std::string subnet_as_string_as_dash_delimiters = subnet_as_string;
+
 
             // Replace dots by dashes
-            std::replace(subnet_as_string_as_dash_delimiters.begin(),
-                subnet_as_string_as_dash_delimiters.end(), '.', '_');
+            std::replace(subnet_as_string.begin(),
+            		subnet_as_string.end(), '.', '_');
 
             // Replace / by dashes too
-            std::replace(subnet_as_string_as_dash_delimiters.begin(),
-                subnet_as_string_as_dash_delimiters.end(), '/', '_');
+            std::replace(subnet_as_string.begin(),
+            		subnet_as_string.end(), '/', '_');
 
-            graphite_data[ graphite_prefix + ".networks." + subnet_as_string_as_dash_delimiters + ".incoming.pps" ] = speed->in_packets;
-            graphite_data[ graphite_prefix + ".networks." + subnet_as_string_as_dash_delimiters + ".outgoing.pps" ] = speed->out_packets; 
+            graphite_data[ graphite_prefix + ".networks." + subnet_as_string + ".incoming.pps" ] = speed->in_packets;
+            graphite_data[ graphite_prefix + ".networks." + subnet_as_string + ".outgoing.pps" ] = speed->out_packets;
 
-            graphite_data[ graphite_prefix + ".networks." + subnet_as_string_as_dash_delimiters + ".incoming.bps" ] = speed->in_bytes * 8; 
-            graphite_data[ graphite_prefix + ".networks." + subnet_as_string_as_dash_delimiters + ".outgoing.bps" ] = speed->out_bytes * 8;
+            graphite_data[ graphite_prefix + ".networks." + subnet_as_string + ".incoming.bps" ] = speed->in_bytes * 8;
+            graphite_data[ graphite_prefix + ".networks." + subnet_as_string + ".outgoing.bps" ] = speed->out_bytes * 8;
         }
     
         buffer


### PR DESCRIPTION
The use of the variable "ip_as_string_with_dash_delimiters" is only to pass the value of "client_ip_as_string", wouldn't be better to just pass "client_ip_as_string" and replace its values? Since its only used for this purpose i think this would be good.

Ps: Maybe make a comment warning the conversion that will happen later in "client_ip_as_string"