### PR TITLE
include sys/socket.h before net/if_arp.h

### DIFF
--- a/src/fastnetmon.cpp
+++ b/src/fastnetmon.cpp
@@ -11,6 +11,7 @@
 #include <time.h>
 #include <unistd.h>
 
+#include <sys/socket.h>
 #include <arpa/inet.h>
 #include <net/if_arp.h> // struct arphdr
 #include <netinet/if_ether.h>
@@ -20,7 +21,6 @@
 #include <netinet/tcp.h>
 #include <netinet/udp.h>
 #include <sys/resource.h>
-#include <sys/socket.h>
 #include <sys/stat.h>
 
 #include "bgp_flow_spec.h"


### PR DESCRIPTION
On least OpenBSD this is required as otherwise the build fails with:

```
/usr/include/net/if_arp.h:79:18: error: field has incomplete type 'struct sockaddr'
```