### PR TITLE
Implemented option to configure delay between traffic recalculations

### DIFF
--- a/src/fastnetmon.conf
+++ b/src/fastnetmon.conf
@@ -139,6 +139,9 @@ average_calculation_time = 5
 # We use average values for traffic speed for subnet and we calculate average over this time slice
 average_calculation_time_for_subnets = 5
 
+# Delay between traffic recalculation attempts
+speed_calculation_delay = 1
+
 # Netflow configuration
 
 # it's possible to specify multiple ports here, using commas as delimiter


### PR DESCRIPTION
I've added new configuration option speed_calculation_delay. It may be very useful with sampled data which is non even stream and in this case we need to disable exponential moving average. 