### PR TITLE
We have to revert process internal as external logic because it block migraiton

### DIFF
--- a/src/fast_library.cpp
+++ b/src/fast_library.cpp
@@ -796,11 +796,7 @@ direction_t get_packet_direction(patricia_tree_t* lookup_tree,
                                uint32_t src_ip,
                                uint32_t dst_ip,
                                unsigned long& subnet,
-                               unsigned int&  subnet_cidr_mask,
-                               unsigned long& destination_subnet,
-                               unsigned int&  destination_subnet_cidr_mask,
-                               unsigned long& source_subnet,
-                               unsigned int&  source_subnet_cidr_mask
+                               unsigned int&  subnet_cidr_mask
                                ) {
     direction_t packet_direction;
 
@@ -816,6 +812,9 @@ direction_t get_packet_direction(patricia_tree_t* lookup_tree,
 
     found_patrica_node = patricia_search_best2(lookup_tree, &prefix_for_check_adreess, 1);
 
+    unsigned long destination_subnet = 0;
+    unsigned int destination_subnet_cidr_mask = 0;
+
     if (found_patrica_node) {
         our_ip_is_destination = true;
         destination_subnet = found_patrica_node->prefix->add.sin.s_addr;
@@ -826,6 +825,9 @@ direction_t get_packet_direction(patricia_tree_t* lookup_tree,
     prefix_for_check_adreess.add.sin.s_addr = src_ip;
 
     found_patrica_node = patricia_search_best2(lookup_tree, &prefix_for_check_adreess, 1);
+
+    unsigned long source_subnet = 0;
+    unsigned int source_subnet_cidr_mask = 0;
 
     if (found_patrica_node) {
         our_ip_is_source = true;

--- a/src/fast_library.h
+++ b/src/fast_library.h
@@ -88,11 +88,7 @@ direction_t get_packet_direction(patricia_tree_t* lookup_tree,
                                uint32_t src_ip,
                                uint32_t dst_ip,
                                unsigned long& subnet,
-                               unsigned int& subnet_cidr_mask,
-                               unsigned long& destination_subnet,
-                               unsigned int&  destination_subnet_cidr_mask,
-                               unsigned long& source_subnet,
-                               unsigned int&  source_subnet_cidr_mas);
+                               unsigned int& subnet_cidr_mask);
 
 direction_t get_packet_direction_ipv6(patricia_tree_t* lookup_tree, struct in6_addr src_ipv6, struct in6_addr dst_ipv6, subnet_ipv6_cidr_mask_t& subnet);
 

--- a/src/fastnetmon.conf
+++ b/src/fastnetmon.conf
@@ -133,9 +133,6 @@ average_calculation_time = 5
 # We use average values for traffic speed for subnet and we calculate average over this time slice
 average_calculation_time_for_subnets = 5
 
-# In this case FastNetMon will account traffic between hosts in your own networks_list as it comes from the outside
-process_internal_traffic_as_external = off
-
 # Delay between traffic recalculation attempts
 speed_calculation_delay = 1
 

--- a/src/fastnetmon.cpp
+++ b/src/fastnetmon.cpp
@@ -133,8 +133,6 @@ unsigned int stats_thread_initial_call_delay = 30;
 // Current time with pretty low precision, we use separate thread to update it
 time_t current_inaccurate_time = 0; 
 
-bool process_internal_traffic_as_external = false;
-
 unsigned int recalculate_speed_timeout = 1;
 
 FastnetmonPlatformConfigurtion fastnetmon_platform_configuration;
@@ -723,14 +721,6 @@ bool load_configuration_file() {
             enable_conection_tracking = true;
         } else {
             enable_conection_tracking = false;
-        }
-    }
-
-    if (configuration_map.count("process_internal_traffic_as_external")) {
-        if (configuration_map["process_internal_traffic_as_external"] == "on") {
-            process_internal_traffic_as_external = true;
-        } else {
-            process_internal_traffic_as_external = false;
         }
     }
 


### PR DESCRIPTION
I've decided to drop process internal as external logic to avoid complexity in coming migration to new counters logic. 