### PR TITLE
Added logic to show total IPv6 counters in fastnetmon_client

### DIFF
--- a/src/fastnetmon.conf
+++ b/src/fastnetmon.conf
@@ -263,8 +263,11 @@ my_hosts_threshold_flows = 3500
 # Path to pid file for checking "if another copy of tool is running", it's useful when you run multiple instances of tool
 pid_path = /var/run/fastnetmon.pid
 
-# Path to file where we store information for fastnetmon_client
+# Path to file where we store IPv4 traffic information for fastnetmon_client
 cli_stats_file_path = /tmp/fastnetmon.dat
+
+# Path to file where we store IPv6 traffic information for fastnetmon_client
+cli_stats_ipv6_file_path = /tmp/fastnetmon_ipv6.dat
 
 # Enable gRPC api (required for fastnetmon_api_client tool)
 enable_api = off

--- a/src/fastnetmon_logic.hpp
+++ b/src/fastnetmon_logic.hpp
@@ -93,11 +93,12 @@ void call_ban_handlers(uint32_t client_ip, attack_details& current_attack, std::
 void store_data_in_mongo(std::string key_name, std::string attack_details_json);
 #endif
 
+std::string print_channel_speed_ipv6(std::string traffic_type, direction_t packet_direction);
 std::string print_channel_speed(std::string traffic_type, direction_t packet_direction);
-void traffic_draw_program();
+void traffic_draw_ipv4_program();
 void recalculate_speed();
 std::string draw_table(direction_t data_direction, bool do_redis_update, sort_type_t sort_item);
-void print_screen_contents_into_file(std::string screen_data_stats_param);
+void print_screen_contents_into_file(std::string screen_data_stats_param, std::string file_path);
 void zeroify_all_flow_counters();
 void process_packet(simple_packet_t& current_packet) ;
 
@@ -137,3 +138,4 @@ void increment_incoming_flow_counters(map_of_vector_counters_for_flow_t& SubnetV
                                       uint64_t sampled_number_of_bytes,
                                       const subnet_cidr_mask_t& current_subnet);
 
+void traffic_draw_ipv6_program();


### PR DESCRIPTION
Hello!

We've reached point to be able to show IPv6 per direction counters in fastnetmon_client:
```
./fastnetmon_client --ipv6
```

Output:
```
FastNetMon 1.1.8 master git-c6a1c98582b9409c552a8be5f3637e1482725b7c Try Advanced edition: https://fastnetmon.com
IPs ordered by: packets
Incoming traffic	  2331 pps     99 mbps

Outgoing traffic	  1657 pps      1 mbps

Internal traffic	     0 pps      0 mbps

Other traffic		     0 pps      0 mbps


```