### PR TITLE
During installation, package python-pip does not exists

### DIFF
--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -20,7 +20,7 @@ RUN apt-get update && apt-get install -y \
   linux-headers-$(uname -r) \
   make \
   mongodb-dev \
-  python-pip \
+  python3-pip \
   socat \
   vim
 


### PR DESCRIPTION
It's renamed to python3-pip