### PR TITLE
BUILDFIX: add missing header for g++13

### DIFF
--- a/src/abstract_subnet_counters.hpp
+++ b/src/abstract_subnet_counters.hpp
@@ -3,6 +3,7 @@
 #include <algorithm>
 #include <mutex>
 #include <unordered_map>
+#include <functional>
 
 // I keep these declaration here because of following error:
 // error: there are no arguments to ‘increment_outgoing_counters’ that depend on a template parameter, so a declaration


### PR DESCRIPTION
With g++13, the following error is produced:

```
src/metrics/../abstract_subnet_counters.hpp:79:28: error: 'std::function' has not been declared
```

Fix this error by including additional header.