### PR TITLE
Fix time

### DIFF
--- a/src/abstract_subnet_counters.hpp
+++ b/src/abstract_subnet_counters.hpp
@@ -18,6 +18,8 @@
 
 #include <boost/serialization/unordered_map.hpp>
 
+extern timespec current_inaccurate_time;
+
 // Class for abstract per key counters
 template <typename T, typename Counter> class abstract_subnet_counters_t {
     public:
@@ -53,10 +55,8 @@ template <typename T, typename Counter> class abstract_subnet_counters_t {
         std::lock_guard<std::mutex> lock_guard(counter_map_mutex);
         Counter& counters = counter_map[key];
 
-        extern time_t current_inaccurate_time;
-
         // Update last update time
-        counters.last_update_time = current_inaccurate_time;
+        counters.last_update_time = current_inaccurate_time.tv_sec;
 
         for (std::size_t current_index = 0; current_index < counters.flexible_counters.size(); current_index++) {
             // Increment only counters which are relevant to specific flexible threshold
@@ -87,10 +87,8 @@ template <typename T, typename Counter> class abstract_subnet_counters_t {
         std::lock_guard<std::mutex> lock_guard(counter_map_mutex);
         Counter& counters = counter_map[key];
 
-        extern time_t current_inaccurate_time;
-
         // Update last update time
-        counters.last_update_time = current_inaccurate_time;
+        counters.last_update_time = current_inaccurate_time.tv_sec;
 
         for (std::size_t current_index = 0; current_index < counters.flexible_counters.size(); current_index++) {
             // Increment only counters which are relevant to specific flexible threshold

--- a/src/afpacket_plugin/afpacket_collector.cpp
+++ b/src/afpacket_plugin/afpacket_collector.cpp
@@ -48,6 +48,9 @@ extern uint64_t total_unparsed_packets;
 // Global configuration map
 extern std::map<std::string, std::string> configuration_map;
 
+// external clock source
+extern timespec current_inaccurate_time;
+
 // This variable name should be uniq for every plugin!
 process_packet_pointer afpacket_process_func_ptr = NULL;
 
@@ -141,6 +144,10 @@ void walk_block(struct block_desc* pbd, const int block_num) {
         u_char* data_pointer = (u_char*)((uint8_t*)ppd + ppd->tp_mac);
 
         simple_packet_t packet;
+
+        // Convert nanosecond to microseconds
+        packet.ts.tv_usec   = current_inaccurate_time.tv_nsec / 1000;
+        packet.ts.tv_sec    = current_inaccurate_time.tv_sec;
 
         // Override default sample rate by rate specified in configuration
         if (mirror_af_packet_custom_sampling_rate > 1) {

--- a/src/fast_library.cpp
+++ b/src/fast_library.cpp
@@ -454,6 +454,8 @@ bool serialize_simple_packet_to_json(const simple_packet_t& packet, nlohmann::js
     try {
 
         json_packet["ip_version"] = protocol_version;
+        json_packet["timestamp_s"] = packet.ts.tv_sec;
+        json_packet["timestamp_ms"] = packet.ts.tv_usec / 1000;
 
         json_packet["source_ip"]      = source_ip_as_string;
         json_packet["destination_ip"] = destination_ip_as_string;

--- a/src/fastnetmon.cpp
+++ b/src/fastnetmon.cpp
@@ -167,7 +167,7 @@ std::string backtrace_path = "/var/log/fastnetmon_backtrace.dump";
 unsigned int check_for_availible_for_processing_packets_buckets = 1;
 
 // Current time with pretty low precision, we use separate thread to update it
-time_t current_inaccurate_time = 0;
+timespec current_inaccurate_time = timespec{};
 
 // This is thread safe storage for captured from the wire packets for IPv6 traffic
 packet_buckets_storage_t<subnet_ipv6_cidr_mask_t> packet_buckets_ipv6_storage;
@@ -1799,7 +1799,8 @@ int main(int argc, char** argv) {
     }
 
     // Set inaccurate time value which will be used in process_packet() from capture backends
-    time(&current_inaccurate_time);
+    // https://stackoverflow.com/questions/6498972/faster-equivalent-of-gettimeofday
+    clock_gettime(CLOCK_MONOTONIC_COARSE, &current_inaccurate_time);
 
     // start thread which pre-calculates speed for system counters
     auto system_counters_speed_thread = new boost::thread(system_counters_speed_thread_handler);

--- a/src/pcap_plugin/pcap_collector.cpp
+++ b/src/pcap_plugin/pcap_collector.cpp
@@ -39,6 +39,8 @@ unsigned int DATA_SHIFT_VALUE = 14;
 
 extern log4cpp::Category& logger;
 extern std::map<std::string, std::string> configuration_map;
+extern timespec current_inaccurate_time;
+
 
 // This variable name should be uniq for every plugin!
 process_packet_pointer pcap_process_func_ptr = NULL;
@@ -109,6 +111,10 @@ void parse_packet(u_char* user, struct pcap_pkthdr* packethdr, const u_char* pac
     unsigned int packet_length = ntohs(iphdr->ip_len);
 
     simple_packet_t current_packet;
+
+    current_packet.ts.tv_sec    = current_inaccurate_time.tv_sec;
+    // Convert nanosecond to microseconds
+    current_packet.ts.tv_usec   = current_inaccurate_time.tv_nsec / 1000;
 
     // Advance to the transport layer header then parse and display
     // the fields based on the type of hearder: tcp, udp or icmp

--- a/src/speed_counters.cpp
+++ b/src/speed_counters.cpp
@@ -2,7 +2,7 @@
 
 #include "fast_library.hpp"
 
-extern time_t current_inaccurate_time;
+extern timespec current_inaccurate_time;
 
 
 #ifdef USE_NEW_ATOMIC_BUILTINS
@@ -13,7 +13,7 @@ void increment_outgoing_counters(subnet_counter_t& current_element,
                                  uint64_t sampled_number_of_bytes) {
 
     // Update last update time
-    current_element.last_update_time = current_inaccurate_time;
+    current_element.last_update_time = current_inaccurate_time.tv_sec;
 
     // Main packet/bytes counter
     __atomic_add_fetch(&current_element.total.out_packets, sampled_number_of_packets, __ATOMIC_RELAXED);
@@ -51,7 +51,7 @@ void increment_outgoing_counters(subnet_counter_t& current_element,
                                  uint64_t sampled_number_of_bytes) {
 
     // Update last update time
-    current_element.last_update_time = current_inaccurate_time;
+    current_element.last_update_time = current_inaccurate_time.tv_sec;
 
     // Main packet/bytes counter
     __sync_fetch_and_add(&current_element.total.out_packets, sampled_number_of_packets);
@@ -92,7 +92,7 @@ void increment_incoming_counters(subnet_counter_t& current_element,
                                  uint64_t sampled_number_of_bytes) {
 
     // Uodate last update time
-    current_element.last_update_time = current_inaccurate_time;
+    current_element.last_update_time = current_inaccurate_time.tv_sec;
 
     // Main packet/bytes counter
     __atomic_add_fetch(&current_element.total.in_packets, sampled_number_of_packets, __ATOMIC_RELAXED);
@@ -133,7 +133,7 @@ void increment_incoming_counters(subnet_counter_t& current_element,
                                  uint64_t sampled_number_of_bytes) {
 
     // Uodate last update time
-    current_element.last_update_time = current_inaccurate_time;
+    current_element.last_update_time = current_inaccurate_time.tv_sec;
 
     // Main packet/bytes counter
     __sync_fetch_and_add(&current_element.total.in_packets, sampled_number_of_packets);

--- a/src/traffic_output_formats/protobuf/protobuf_traffic_format.cpp
+++ b/src/traffic_output_formats/protobuf/protobuf_traffic_format.cpp
@@ -11,8 +11,8 @@ bool write_simple_packet_to_protobuf(const simple_packet_t& packet, TrafficData&
     // 1
     traffic_data.set_timestamp_seconds(packet.ts.tv_sec);
 
-    // 2
-    traffic_data.set_timestamp_milliseconds(packet.ts.tv_usec);
+    // 2 convert microsecond to millisecond
+    traffic_data.set_timestamp_milliseconds(packet.ts.tv_usec / 1000);
 
     // 3
     if (packet.source == MIRROR) {

--- a/src/xdp_plugin/xdp_collector.cpp
+++ b/src/xdp_plugin/xdp_collector.cpp
@@ -49,7 +49,7 @@ extern "C" {
 // Our new generation parser
 #include "../simple_packet_parser_ng.hpp"
 
-extern time_t current_inaccurate_time;
+extern timespec current_inaccurate_time;
 
 // Global configuration map
 extern std::map<std::string, std::string> configuration_map;
@@ -492,7 +492,11 @@ void xdp_process_traffic(int xdp_socket, xsk_memory_configuration* mem_configura
 
             simple_packet_t packet;
             packet.source       = MIRROR;
-            packet.arrival_time = current_inaccurate_time;
+            packet.arrival_time = current_inaccurate_time.tv_sec;
+            // also set other time fields
+            packet.ts.tv_sec    = current_inaccurate_time.tv_sec;
+            // Convert nanosecond to microseconds
+            packet.ts.tv_usec   = current_inaccurate_time.tv_nsec / 1000;
 
             bool xdp_extract_tunnel_traffic = false;
 


### PR DESCRIPTION
Currently the JSON Fields are mising and Protobuf Fields are set to zero if not using IPFIX/Netflow. This change adds the missing fields, corrects the value inside the proto filed and replaces the global time with clock_gettime to allow usage of nanoseconds