### PR TITLE
Prioritize find_package config mode for Protobuf

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -594,26 +594,26 @@ if (ENABLE_GOBGP_SUPPORT)
         target_link_libraries(gobgp_action absl::base absl::synchronization)
     endif()
 
-    # By default use module supplied by cmake to search for Protobuf 
-    set(FIND_PACKAGE_MODE_PROTOBUF "MODULE")
-
     if (DO_NOT_USE_SYSTEM_LIBRARIES_FOR_BUILD)
       # We add our custom path to Protobuf to top of search_list used by find_package: https://cmake.org/cmake/help/latest/variable/CMAKE_PREFIX_PATH.html
       # This approach has advantage over Protobuf_DIR which requires us to set direct path to cmake folder of custom built dependency
       # which resides in vendor specific folder with name lib which may be lib64 on CentOS platforms:
       # protobuf_21_12/lib/cmake/protobuf or  protobuf_21_12/lib64/cmake/protobuf on CentOS 
       list(APPEND CMAKE_PREFIX_PATH ${PROTOCOL_BUFFERS_CUSTOM_INSTALL_PATH}) 
-
-      # Switch to use to configuration supplied by custom Protobuf installation as it may be better
-      set(FIND_PACKAGE_MODE_PROTOBUF "CONFIG")
-
-      # Apparently it's required to set this flag because without this flag set it cannot find protoc when custom library path is in use
-      # https://github.com/protocolbuffers/protobuf/issues/1931
-      set(protobuf_MODULE_COMPATIBLE true)
     endif()
 
-    # https://cmake.org/cmake/help/latest/module/FindProtobuf.html
-    find_package(Protobuf ${FIND_PACKAGE_MODE_PROTOBUF} REQUIRED)
+    # Apparently it's required to set this flag because without this flag set it cannot find protoc when custom library path is in use
+    # https://github.com/protocolbuffers/protobuf/issues/1931
+    set(protobuf_MODULE_COMPATIBLE true)
+
+    # Switch to use to configuration supplied by custom Protobuf installation as it may be better
+    find_package(Protobuf CONFIG)
+
+    if (NOT Protobuf_FOUND)
+      # Fall back to module supplied by cmake to search for Protobuf
+      # https://cmake.org/cmake/help/latest/module/FindProtobuf.html
+      find_package(Protobuf MODULE REQUIRED)
+    endif()
 
     if (Protobuf_FOUND)
       message(STATUS "Found Protobuf ${Protobuf_VERSION}")


### PR DESCRIPTION
This sets correct C++ standard for newer Protobuf installations as FindProtobuf module only sets cxx_std_11

---

Otherwise, since `CMAKE_CXX_STANDARD` is not forced, the build will default to `-std=gnu++11`, e.g.
```
[ 41%] Building CXX object CMakeFiles/attribute_pb_cc.dir/gobgp_client/attribute.pb.cc.o
/opt/homebrew/Library/Homebrew/shims/mac/super/clang++ -DDECLARE_FAKE_BPF_LINK_TYPE -DDECLARE_FAKE_BPF_STATS -DENABLE_CAPNP -DENABLE_GOBGP -DENABLE_PCAP -DFASTNETMON_API -DMONGO -DREDIS -I/opt/fastnetmon-community/libraries/abseil_2022_06_23/include -I/opt/fastnetmon-community/libraries/capnproto_0_8_0/include -I/opt/homebrew/include/libmongoc-1.0 -I/opt/homebrew/include/libbson-1.0 --std=c++20 -O3 -DNDEBUG -std=gnu++11 -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX14.sdk   -Wreorder -Wunused -Wparentheses -Wimplicit-fallthrough -Wreturn-type -Wuninitialized -Winit-self -Wmaybe-uninitialized -Wcatch-value=3 -Wclass-memaccess -MD -MT CMakeFiles/attribute_pb_cc.dir/gobgp_client/attribute.pb.cc.o -MF CMakeFiles/attribute_pb_cc.dir/gobgp_client/attribute.pb.cc.o.d -o CMakeFiles/attribute_pb_cc.dir/gobgp_client/attribute.pb.cc.o -c /tmp/fastnetmon-20231226-82930-1elr23/fastnetmon-1.2.6/src/gobgp_client/attribute.pb.cc
```

Which then results in build failure:
```
In file included from /tmp/fastnetmon-20231226-82930-1elr23/fastnetmon-1.2.6/src/gobgp_client/attribute.pb.cc:4:
In file included from /tmp/fastnetmon-20231226-82930-1elr23/fastnetmon-1.2.6/src/gobgp_client/attribute.pb.h:13:
In file included from /opt/homebrew/include/google/protobuf/port_def.inc:33:
In file included from /opt/homebrew/include/absl/base/attributes.h:37:
In file included from /opt/homebrew/include/absl/base/config.h:86:
/opt/homebrew/include/absl/base/policy_checks.h:79:2: error: "C++ versions less than C++14 are not supported."
#error "C++ versions less than C++14 are not supported."
 ^
```

---

On side note, forcing `-DCMAKE_CXX_STANDARD=20` will get past above failure and then fail if Protobuf is linked to Abseil:
```
[ 81%] Linking CXX executable fastnetmon_api_client
/opt/homebrew/Cellar/cmake/3.28.1/bin/cmake -E cmake_link_script CMakeFiles/fastnetmon_api_client.dir/link.txt --verbose=1
/opt/homebrew/Library/Homebrew/shims/mac/super/clang++  --std=c++20 -O3 -DNDEBUG -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX14.sdk -Wl,-search_paths_first -Wl,-headerpad_max_install_names CMakeFiles/fastnetmon_api_client.dir/fastnetmon_api_client.cpp.o -o fastnetmon_api_client  /opt/homebrew/lib/libabsl_synchronization.2308.0.0.dylib /opt/homebrew/lib/libgpr.dylib /opt/homebrew/lib/libgrpc++.dylib /opt/homebrew/lib/libgrpc.dylib libfastnetmon_grpc_pb_cc.a libfastnetmon_pb_cc.a /opt/homebrew/lib/libprotobuf.dylib /opt/homebrew/lib/libabsl_graphcycles_internal.2308.0.0.dylib /opt/homebrew/lib/libabsl_kernel_timeout_internal.2308.0.0.dylib /opt/homebrew/lib/libabsl_stacktrace.2308.0.0.dylib /opt/homebrew/lib/libabsl_symbolize.2308.0.0.dylib /opt/homebrew/lib/libabsl_malloc_internal.2308.0.0.dylib /opt/homebrew/lib/libabsl_debugging_internal.2308.0.0.dylib /opt/homebrew/lib/libabsl_demangle_internal.2308.0.0.dylib /opt/homebrew/lib/libabsl_time.2308.0.0.dylib /opt/homebrew/lib/libabsl_strings.2308.0.0.dylib /opt/homebrew/lib/libabsl_string_view.2308.0.0.dylib /opt/homebrew/lib/libabsl_strings_internal.2308.0.0.dylib /opt/homebrew/lib/libabsl_base.2308.0.0.dylib /opt/homebrew/lib/libabsl_spinlock_wait.2308.0.0.dylib /opt/homebrew/lib/libabsl_throw_delegate.2308.0.0.dylib /opt/homebrew/lib/libabsl_raw_logging_internal.2308.0.0.dylib /opt/homebrew/lib/libabsl_log_severity.2308.0.0.dylib /opt/homebrew/lib/libabsl_civil_time.2308.0.0.dylib /opt/homebrew/lib/libabsl_int128.2308.0.0.dylib /opt/homebrew/lib/libabsl_time_zone.2308.0.0.dylib -Wl,-framework,CoreFoundation
ld: Undefined symbols:
  absl::lts_20230802::cord_internal::InitializeCordRepExternal(std::__1::basic_string_view<char, std::__1::char_traits<char>>, absl::lts_20230802::cord_internal::CordRepExternal*), referenced from:
      absl::lts_20230802::Cord absl::lts_20230802::MakeCordFromExternal<grpc::ProtoBufferReader::MakeCordFromSlice(grpc_slice)::'lambda'(std::__1::basic_string_view<char, std::__1::char_traits<char>>)>(std::__1::basic_string_view<char, std::__1::char_traits<char>>, grpc::ProtoBufferReader::MakeCordFromSlice(grpc_slice)::'lambda'(std::__1::basic_string_view<char, std::__1::char_traits<char>>)&&) in fastnetmon_api_client.cpp.o
  absl::lts_20230802::Cord::DestroyCordSlow(), referenced from:
      absl::lts_20230802::Cord::~Cord() in fastnetmon_api_client.cpp.o
  absl::lts_20230802::Cord::Append(absl::lts_20230802::Cord&&), referenced from:
      grpc::ProtoBufferReader::ReadCord(absl::lts_20230802::Cord*, int) in fastnetmon_api_client.cpp.o
      grpc::ProtoBufferReader::ReadCord(absl::lts_20230802::Cord*, int) in fastnetmon_api_client.cpp.o
      grpc::ProtoBufferReader::ReadCord(absl::lts_20230802::Cord*, int) in fastnetmon_api_client.cpp.o
      grpc::ProtoBufferReader::ReadCord(absl::lts_20230802::Cord*, int) in fastnetmon_api_client.cpp.o
  absl::lts_20230802::Cord::Subcord(unsigned long, unsigned long) const, referenced from:
      grpc::ProtoBufferWriter::WriteCord(absl::lts_20230802::Cord const&) in libfastnetmon_grpc_pb_cc.a[2](fastnetmon.grpc.pb.cc.o)
clang: error: linker command failed with exit code 1 (use -v to see invocation)
make[2]: *** [fastnetmon_api_client] Error 1
make[1]: *** [CMakeFiles/fastnetmon_api_client.dir/all] Error 2
make[1]: *** Waiting for unfinished jobs....
```