### PR TITLE
Do not use implicit conversion from 0/nullptr to std::string

### DIFF
--- a/src/fast_library.cpp
+++ b/src/fast_library.cpp
@@ -144,7 +144,7 @@ std::string get_net_address_from_network_as_string(std::string network_cidr_form
     split(subnet_as_string, network_cidr_format, boost::is_any_of("/"), boost::token_compress_on);
 
     if (subnet_as_string.size() != 2) {
-        return 0;
+        return std::string();
     }
 
     return subnet_as_string[0];


### PR DESCRIPTION
Hi, as far as I know, `std::string` should not be constructed from `nullptr` or `0` literal.
PTAL