### PR TITLE
Remove `gpr_set_log_function`

### DIFF
--- a/src/fastnetmon.cpp
+++ b/src/fastnetmon.cpp
@@ -464,10 +464,6 @@ void free_up_all_resources();
 void interruption_signal_handler(int signal_number);
 
 #ifdef FASTNETMON_API
-void silent_logging_function(gpr_log_func_args* args) {
-    // We do not want any logging here
-}
-
 // We could not define this variable in top of the file because we should define class before
 FastnetmonApiServiceImpl api_service;
 
@@ -1863,10 +1859,6 @@ int main(int argc, char** argv) {
         ifs.close();
         std::filesystem::remove(fastnetmon_platform_configuration.backtrace_path);
     }
-
-#ifdef FASTNETMON_API
-    gpr_set_log_function(silent_logging_function);
-#endif
 
     // Set default ban configuration
     init_global_ban_settings();

--- a/src/fastnetmon_api_client.cpp
+++ b/src/fastnetmon_api_client.cpp
@@ -90,10 +90,6 @@ class FastnetmonClient {
     std::unique_ptr<Fastnetmon::Stub> stub_;
 };
 
-void silent_logging_function(gpr_log_func_args* args) {
-    // We do not want any logging here
-}
-
 int main(int argc, char** argv) {
     std::string supported_commands_list = "ban, unban, get_banlist";
 
@@ -101,8 +97,6 @@ int main(int argc, char** argv) {
         std::cerr << "Please provide command as argument, supported commands: " << supported_commands_list << std::endl;
         return 1;
     }
-
-    gpr_set_log_function(silent_logging_function);
 
     // Instantiate the client. It requires a channel, out of which the actual RPCs
     // are created. This channel models a connection to an endpoint (in this case,


### PR DESCRIPTION
This has been removed in grpc/grpc@d3560d9176acfc67a498297fa2d3a45065e82e71.

This fixes a build failure with gRPC 1.67.
