### PR TITLE
Fix build with Boost 1.89.0

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -844,7 +844,7 @@ set(Boost_DETAILED_FAILURE_MSG ON)
 # Boost.System is a library that, in essence, defines four classes to identify errors. All four classes were added to the standard library with C++11. If your development environment supports C++11, you don’t need to use Boost.System. However, since many Boost libraries use Boost.System, you might encounter Boost.System through those other libraries.
 # Boost.System is a library that, in essence, defines four classes to identify errors. All four classes were added to the standard library with C++11. If your development environment supports C++11, you don’t need to use Boost.System. However, since many Boost libraries use Boost.System, you might encounter Boost.System through those other libraries.
 # TODO: we may not need system at all
-find_package(Boost COMPONENTS serialization thread regex program_options system REQUIRED ${DISABLE_DEFAULT_PATH_SEARCH_VAR})
+find_package(Boost COMPONENTS serialization thread regex program_options OPTIONAL_COMPONENTS system REQUIRED ${DISABLE_DEFAULT_PATH_SEARCH_VAR})
 
 if(Boost_FOUND)
     message(STATUS "Found Boost: ${Boost_LIBRARIES} ${Boost_INCLUDE_DIRS}")


### PR DESCRIPTION
In the upcoming Boost 1.89.0 release, Boost.System stub library has been removed (https://github.com/boostorg/system/commit/7a495bb46d7ccd808e4be2a6589260839b0fd3a3) which causes a CMake error.

I noticed this while testing 1.89.0.beta1 in Homebrew https://github.com/Homebrew/homebrew-core/pull/233031.

Moved `system` to OPTIONAL_COMPONENTS based on upstream suggestion at https://github.com/boostorg/system/issues/132#issuecomment-3146378680

Though there is a TODO comment mentioning not needing `system` so an alternative could be to remove it. This is definitely safe for Boost 1.69[^1] or newer where Boost.System is header-only though would need confirmation on older Boost.

[^1]: https://www.boost.org/doc/libs/1_69_0/libs/system/doc/html/system.html#changes_in_boost_1_69