### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/docker-builds.yml
+++ b/.github/workflows/docker-builds.yml
@@ -7,6 +7,9 @@ on:
     branches:
       - master
 
+permissions:
+  contents: read
+
 jobs:
     build_in_docker:
         strategy:


### PR DESCRIPTION
Potential fix for [https://github.com/pavel-odintsov/fastnetmon/security/code-scanning/1](https://github.com/pavel-odintsov/fastnetmon/security/code-scanning/1)

Add an explicit top-level `permissions` block to `.github/workflows/docker-builds.yml` so all jobs inherit minimal token scope unless overridden.  
Best fix without changing functionality: add:

- `permissions:`
- `contents: read`

directly under the `on:` block (before `jobs:`), or right after `name:`/`on:` section. This preserves existing behavior for checkout/build while ensuring the token cannot write by default.

No imports, methods, or dependencies are needed; this is a YAML workflow configuration change only.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
