### PR TITLE
Potential fix for code scanning alert no. 5: Wrong type of arguments to formatting function

### DIFF
--- a/src/tests/lpm_performance_tests.cpp
+++ b/src/tests/lpm_performance_tests.cpp
@@ -199,7 +199,7 @@ int main() {
     unsigned long total_ops    = i_iter * j_iter;
     float megaops_per_second   = (float)total_ops / (float)used_seconds / 1000000;
 
-    printf("Total time is %d seconds total ops: %d\nMillion of ops per second: %.1f\n", used_seconds, total_ops, megaops_per_second);
+    printf("Total time is %lu seconds total ops: %lu\nMillion of ops per second: %.1f\n", used_seconds, total_ops, megaops_per_second);
 
     Destroy_Patricia(lookup_tree);
 }


### PR DESCRIPTION
Potential fix for [https://github.com/pavel-odintsov/fastnetmon/security/code-scanning/5](https://github.com/pavel-odintsov/fastnetmon/security/code-scanning/5)

Update the `printf` format specifiers on line 202 in `src/tests/lpm_performance_tests.cpp` to match the actual argument types without changing behavior:

- `used_seconds` is `unsigned long` → use `%lu`
- `total_ops` is `unsigned long` → use `%lu`
- `megaops_per_second` is `float`, promoted to `double` in variadic calls → `%.1f` is already correct

So the best fix is to change:
`"Total time is %d seconds total ops: %d\nMillion of ops per second: %.1f\n"`
to
`"Total time is %lu seconds total ops: %lu\nMillion of ops per second: %.1f\n"`

No new methods, imports, or definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
