### PR TITLE
Potential fix for code scanning alert no. 2: File opened with O_CREAT flag but without mode argument

### DIFF
--- a/src/tests/pcap_writer.cpp
+++ b/src/tests/pcap_writer.cpp
@@ -34,7 +34,7 @@ int main() {
     // Dump buffer to memory
     std::string pcap_file_path = "/tmp/fastnetmon_example.pcap";
 
-    int filedesc = open(pcap_file_path.c_str(), O_WRONLY | O_CREAT);
+    int filedesc = open(pcap_file_path.c_str(), O_WRONLY | O_CREAT, S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH);
 
     if (filedesc <= 0) {
         printf("Can't open dump file for writing");


### PR DESCRIPTION
Potential fix for [https://github.com/pavel-odintsov/fastnetmon/security/code-scanning/2](https://github.com/pavel-odintsov/fastnetmon/security/code-scanning/2)

Use the 3-argument `open` form and provide explicit file permissions.  
Best fix without changing intended behavior: update line 37 in `src/tests/pcap_writer.cpp` to include a sane mode such as `S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH` (octal `0644`) for a typical writable-by-owner, readable-by-others pcap file. No new includes are needed because `<fcntl.h>` is already present and defines these mode bits on common systems.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
