### PR TITLE
Potential fix for code scanning alert no. 3: Multiplication result converted to larger type

### DIFF
--- a/src/afpacket_plugin/afpacket_collector.cpp
+++ b/src/afpacket_plugin/afpacket_collector.cpp
@@ -390,7 +390,7 @@ bool setup_socket(std::string interface_name, bool enable_fanout, int fanout_gro
         return false;
     }
 
-    size_t buffer_size = req.tp_block_size * req.tp_block_nr;
+    size_t buffer_size = static_cast<size_t>(req.tp_block_size) * static_cast<size_t>(req.tp_block_nr);
 
     logger << log4cpp::Priority::DEBUG << "Allocating " << buffer_size << " byte buffer for AF_PACKET interface: " << interface_name;
 


### PR DESCRIPTION
Potential fix for [https://github.com/pavel-odintsov/fastnetmon/security/code-scanning/3](https://github.com/pavel-odintsov/fastnetmon/security/code-scanning/3)

The correct fix is to force multiplication to occur in the wider type (`size_t`) by casting at least one operand before multiplication.

Best minimal change (without altering behavior beyond preventing overflow in intermediate type):
- In `src/afpacket_plugin/afpacket_collector.cpp`, replace:
  - `size_t buffer_size = req.tp_block_size * req.tp_block_nr;`
- With:
  - `size_t buffer_size = static_cast<size_t>(req.tp_block_size) * static_cast<size_t>(req.tp_block_nr);`

This ensures the arithmetic is performed as `size_t` and avoids 32-bit intermediate overflow. No new headers, methods, or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
