### PR TITLE
Add init support for snap

### DIFF
--- a/.github/workflows/snap.yml
+++ b/.github/workflows/snap.yml
@@ -1,0 +1,105 @@
+name: Buld snap package
+
+on:
+  pull_request:
+  push:
+    branches:
+      - "**"
+    tags:
+      - "v*"
+  workflow_dispatch:
+
+
+permissions:
+  contents: read
+
+jobs:
+  build_snap:
+    runs-on: ubuntu-24.04
+    defaults:
+      run:
+        working-directory: ./src
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v6
+
+      - name: Install tools
+        run: |
+          sudo snap install yq
+          sudo snap install snapcraft --classic
+          sudo snap install lxd
+          sudo lxd init --auto
+          sudo usermod -aG lxd "$USER"
+    # snapcraft don't like our src/packaging path
+      - name: Create symlink to snap
+        run: ln -s packaging/snap snap
+      - name: Prepare snapcraft.yaml
+        env:
+          REF_TYPE: ${{ github.ref_type }}
+          REF_NAME: ${{ github.ref_name }}
+          SHA: ${{ github.sha }}
+        run: |
+          set -eux
+
+          SHORT_SHA="$(echo "$SHA" | cut -c1-7)"
+          BASE_VERSION="1.2.9"
+          SNAPCRAFT_FILE="snap/snapcraft.yaml"
+
+          if [ "$REF_TYPE" = "tag" ] && echo "$REF_NAME" | grep -Eq '^v[0-9]'; then
+            FNM_VERSION="${REF_NAME#v}"
+            FNM_GRADE="stable"
+          else
+            FNM_VERSION="${BASE_VERSION}-dev.${SHORT_SHA}"
+            FNM_GRADE="devel"
+          fi
+          export FNM_VERSION
+          export FNM_GRADE
+
+          yq -i '
+            .version = strenv(FNM_VERSION) |
+            .grade = strenv(FNM_GRADE)
+          ' "$SNAPCRAFT_FILE"
+
+          echo "FNM_VERSION=$FNM_VERSION" >> "$GITHUB_ENV"
+          cat "$SNAPCRAFT_FILE"
+
+      - name: Build snap
+        run: |
+            set -eux
+
+            #sg lxd -c 'snapcraft pack'
+            sudo snapcraft pack --destructive-mode
+
+            FNM_SNAP_PATH="$(ls -1 "$PWD"/fastnetmon-community_*.snap | tail -n1)"
+            FNM_SNAP_FILE="$(basename "$FNM_SNAP_PATH")"
+
+            echo "FNM_SNAP_PATH=$FNM_SNAP_PATH" >> "$GITHUB_ENV"
+            echo "FNM_SNAP_FILE=$FNM_SNAP_FILE" >> "$GITHUB_ENV"
+
+            ls -lah "$FNM_SNAP_PATH"
+
+
+
+      - name: Install local snap
+        run: |
+          sudo snap install "$FNM_SNAP_PATH" --dangerous --classic
+
+      - name: Smoke test
+        run: |
+          echo "snap list fastnetmon-community"
+          snap list fastnetmon-community
+          echo -e "\nsnap info fastnetmon-community"
+          snap info fastnetmon-community
+
+          echo -e "\n\nfastnetmon --version"
+          fastnetmon-community.fastnetmon --version
+          echo -e "fastnetmon --configuration_check"
+          sudo fastnetmon-community.fastnetmon --configuration_check
+
+          echo -e "\n\nfastnetmon-client --help"
+          fastnetmon-community.fastnetmon-client --help || true
+          echo -e "fastnetmon-api-client --help"
+          fastnetmon-community.fastnetmon-api-client --help || true
+
+          echo -e "\n\nsnap services fastnetmon-community"
+          snap services fastnetmon-community

--- a/src/packaging/snap/hooks/install
+++ b/src/packaging/snap/hooks/install
@@ -1,0 +1,54 @@
+#!/bin/sh
+set -eu
+
+#CONFIG_DIR="$SNAP_COMMON/etc"
+#LOG_DIR="$SNAP_COMMON/log"
+CONFIG_DIR="/etc"
+LOG_DIR="/var/log/fastnetmon_attacks"
+
+mkdir -p "$CONFIG_DIR"
+mkdir -p "$LOG_DIR"
+
+copy_if_missing() {
+    src="$1"
+    dst="$2"
+
+    if [ ! -f "$dst" ]; then
+        if [ -f "$src" ]; then
+            cp "$src" "$dst"
+        else
+            echo "Missing default file: $src" >&2
+            exit 1
+        fi
+    fi
+}
+
+copy_config_if_missing() {
+    src="$1"
+    dst="$2"
+
+    if [ ! -f "$dst" ]; then
+        if [ ! -f "$src" ]; then
+            echo "Missing default config file: $src" >&2
+            exit 1
+        fi
+
+        cp "$src" "$dst"
+
+        # Edit only the newly created writable copy.
+        sed -i "s|^networks_list_path *=.*|networks_list_path = $CONFIG_DIR/networks_list|" "$dst"
+        sed -i "s|^networks_whitelist_path *=.*|networks_whitelist_path = $CONFIG_DIR/networks_whitelist|" "$dst"
+
+        echo "Created initial config: $dst" >&2
+    else
+        echo "Config already exists, leaving unchanged: $dst" >&2
+    fi
+}
+
+
+copy_config_if_missing "$SNAP/etc/fastnetmon.conf" "$CONFIG_DIR/fastnetmon.conf"
+copy_if_missing "$SNAP/etc/networks_list" "$CONFIG_DIR/networks_list"
+copy_if_missing "$SNAP/etc/networks_whitelist" "$CONFIG_DIR/networks_whitelist"
+
+
+mkdir -p /var/log/fastnetmon_attacks

--- a/src/packaging/snap/snapcraft.yaml
+++ b/src/packaging/snap/snapcraft.yaml
@@ -1,0 +1,174 @@
+name: fastnetmon-community
+base: core24
+version: '1.2.9'
+summary: FastNetMon Community DDoS detection sensor
+license: GPL-2.0-only
+description: |
+  FastNetMon Community is a high-performance DDoS detection sensor
+  supporting NetFlow, IPFIX, sFlow, PCAP and AF_PACKET traffic sources.
+contact: support@fastnetmon.com
+website: https://fastnetmon.com/
+issues: https://github.com/pavel-odintsov/fastnetmon/issues
+source-code: https://github.com/pavel-odintsov/fastnetmon
+
+grade: devel
+confinement: classic
+
+platforms:
+  amd64:
+    build-on: [amd64]
+    build-for: [amd64]
+
+apps:
+  fastnetmon:
+    command: usr/sbin/fastnetmon
+      #environment:
+      #   LD_LIBRARY_PATH: $SNAP/usr/lib/x86_64-linux-gnu
+    plugs:
+      - network
+      - network-bind
+      - network-observe
+  fastnetmon-service:
+    #command: usr/sbin/fastnetmon --configuration_file $SNAP_DATA/fastnetmon.conf
+    #command: usr/sbin/fastnetmon --configuration_file $SNAP_COMMON/etc/fastnetmon.conf
+    command: usr/sbin/fastnetmon --configuration_file /etc/fastnetmon.conf
+      #environment:
+      #   LD_LIBRARY_PATH: $SNAP/usr/lib/x86_64-linux-gnu
+    daemon: simple
+    restart-condition: on-failure
+    plugs:
+      - network
+      - network-bind
+      - network-observe
+
+  fastnetmon-client:
+    command: usr/bin/fastnetmon_client
+      #environment:
+      #   LD_LIBRARY_PATH: $SNAP/usr/lib/x86_64-linux-gnu
+    plugs:
+      - network
+
+  fastnetmon-api-client:
+    command: usr/bin/fastnetmon_api_client
+      #environment:
+      #   LD_LIBRARY_PATH: $SNAP/usr/lib/x86_64-linux-gnu
+    plugs:
+      - network
+
+parts:
+  fastnetmon:
+    plugin: cmake
+    source: .
+    source-type: local
+
+    # for build with getting code from git change to
+    #source: https://github.com/pavel-odintsov/fastnetmon.git
+    #source-type: git
+    #source-tag: v1.2.9
+    ## source-branch: 
+    #source-subdir: src
+
+    cmake-parameters:
+      - -DCMAKE_BUILD_TYPE=Release
+      - -DCMAKE_INSTALL_PREFIX=/usr
+
+      # Flags from Debian/Ubuntu packaging
+      - -DENABLE_CUSTOM_BOOST_BUILD=FALSE
+      - -DDO_NOT_USE_SYSTEM_LIBRARIES_FOR_BUILD=FALSE
+      - -DLINK_WITH_ABSL=TRUE
+
+      # For snap we probably do not need real systemd unit installation,
+      # but keeping the path harmlessly aligned with Debian is OK.
+      - -DCMAKE_INSTALL_SYSTEMD_SERVICEDIR=/usr/lib/systemd/system
+
+
+    build-packages:
+      - cmake
+      - pkgconf
+      - git
+      - build-essential
+
+      - libboost-atomic-dev
+      - libboost-chrono-dev
+      - libboost-date-time-dev
+      - libboost-program-options-dev
+      - libboost-regex-dev
+      - libboost-thread-dev
+
+      - libbpf-dev
+      - libelf-dev
+      - libbson-dev
+      - libcapnp-dev
+      - libgrpc-dev
+      - libgrpc++-dev
+      - libprotobuf-dev
+      - protobuf-compiler
+      - protobuf-compiler-grpc
+      - capnproto
+
+      - libhiredis-dev
+      - liblog4cpp5-dev
+      - libicu-dev
+      - libmongoc-dev
+      - libncurses-dev
+      - libpcap-dev
+
+      # Not listed directly in Debian control, but useful on Ubuntu/core24
+      # if gRPC/Abseil linkage is not pulled transitively enough.
+      - libabsl-dev
+
+      # for override  https://documentation.ubuntu.com/snapcraft/9.0/how-to/debugging/use-the-classic-linter/#patch-elf-binaries
+      - patchelf
+      - binutils
+
+    stage-packages:
+      # gRPC / protobuf / abseil
+      - libgrpc++1.51
+      - libgrpc++1.51t64
+      - libgrpc29
+        #- libgpr29
+      - libprotobuf32
+      - libabsl20220623t64
+
+      # FastNetMon direct deps
+      - liblog4cpp5v5
+      - libpcap0.8
+      - libhiredis1.1.0
+      - libmongoc-1.0-0
+      - libbson-1.0-0
+
+      # Boost runtime
+      - libboost-thread1.83.0
+      - libboost-program-options1.83.0
+
+      # Cap'n Proto
+      - libcapnp-1.0.1
+        #- libkj-1.0.1
+
+      # CLI / terminal
+      - libncurses6
+      - libtinfo6
+
+      # Already resolved from base/host in your ldd, but harmless and safer
+      - libbpf1
+      - libelf1
+      - zlib1g
+      - libssl3
+
+    override-prime: |
+      craftctl default
+
+      RPATH='/snap/fastnetmon-community/current/usr/lib/x86_64-linux-gnu:/snap/fastnetmon-community/current/lib/x86_64-linux-gnu:/snap/fastnetmon-community/current/usr/lib:/snap/fastnetmon-community/current/lib'
+      INTERPRETER='/snap/core24/current/lib64/ld-linux-x86-64.so.2'
+
+      for bin in \
+        usr/sbin/fastnetmon \
+        usr/bin/fastnetmon_client \
+        usr/bin/fastnetmon_api_client
+      do
+        if [ -f "$bin" ]; then
+          echo "Patching ELF: $bin"
+          patchelf --set-interpreter "$INTERPRETER" "$bin"
+          patchelf --force-rpath --set-rpath "$RPATH" "$bin"
+        fi
+      done


### PR DESCRIPTION
Add snapcraft.yaml to build snap from code.

And GitHub Actions - snap.yaml, to build snap package, then install it on runner to check, that it not broken.

For now without saving it or pushing to snapstore.

Command call binary by default would be 
```
fastnetmon-community.fastnetmon
fastnetmon-communtiy.fastnetmon-client
fastnetmon-communtiy.fastnetmon-api-client
```
but could be changed later by user with aliases - 
```
snap alias fastnetmon-community.fastnetmon-client fastnetmon-client
snap alias fastnetmon-community.fastnetmon fastnetmon
snap alias fastnetmon-community.fastnetmon-api-client \fastnetmon-api-client
```
