### PR TITLE
upgrade test to separate runner, share builded snap via artifact

### DIFF
--- a/.github/workflows/snap.yml
+++ b/.github/workflows/snap.yml
@@ -12,6 +12,7 @@ on:
 
 permissions:
   contents: read
+  actions: write
 
 jobs:
   build_snap:
@@ -19,6 +20,14 @@ jobs:
     defaults:
       run:
         working-directory: ./src
+    outputs:
+      fnm_version: ${{ steps.meta.outputs.fnm_version }}
+      fnm_grade: ${{ steps.meta.outputs.fnm_grade }}
+      fnm_channel: ${{ steps.meta.outputs.fnm_channel }}
+      fnm_publishable: ${{ steps.meta.outputs.fnm_publishable }}
+      fnm_snap_file: ${{ steps.build.outputs.fnm_snap_file }}
+      fnm_artifact_name: ${{ steps.build.outputs.fnm_artifact_name }}
+      fnm_artifact_id: ${{ steps.upload.outputs.artifact-id }}
     steps:
       - name: Checkout source
         uses: actions/checkout@v6
@@ -27,13 +36,15 @@ jobs:
         run: |
           sudo snap install yq
           sudo snap install snapcraft --classic
-          sudo snap install lxd
-          sudo lxd init --auto
-          sudo usermod -aG lxd "$USER"
-    # snapcraft don't like our src/packaging path
+        # Not needed, since switched to snapcraft pack with  --destructive-mode flag
+        # sudo snap install lxd
+        # sudo lxd init --auto
+        # sudo usermod -aG lxd "$USER"
+      # snapcraft don't like our src/packaging path
       - name: Create symlink to snap
         run: ln -s packaging/snap snap
       - name: Prepare snapcraft.yaml
+        id: meta
         env:
           REF_TYPE: ${{ github.ref_type }}
           REF_NAME: ${{ github.ref_name }}
@@ -48,22 +59,46 @@ jobs:
           if [ "$REF_TYPE" = "tag" ] && echo "$REF_NAME" | grep -Eq '^v[0-9]'; then
             FNM_VERSION="${REF_NAME#v}"
             FNM_GRADE="stable"
+            FNM_CHANNEL="stable"
+            FNM_PUBLISHABLE="true"
+          elif [ "$GITHUB_REF" = "refs/heads/master" ]; then
+            FNM_VERSION="${BASE_VERSION}-dev.${SHORT_SHA}"
+            FNM_GRADE="devel"
+            FNM_CHANNEL="edge"
+            FNM_PUBLISHABLE="true"
           else
             FNM_VERSION="${BASE_VERSION}-dev.${SHORT_SHA}"
             FNM_GRADE="devel"
+            FNM_CHANNEL=""
+            FNM_PUBLISHABLE="false"
           fi
           export FNM_VERSION
           export FNM_GRADE
 
+          echo "We have version: $FNM_VERSION grade: $FNM_GRADE channel: $FNM_CHANNEL publish: $FNM_PUBLISHABLE"
+          echo "Update $SNAPCRAFT_FILE"
           yq -i '
             .version = strenv(FNM_VERSION) |
             .grade = strenv(FNM_GRADE)
           ' "$SNAPCRAFT_FILE"
 
+          echo "Check new version and grade in $SNAPCRAFT_FILE"
+          test "$(yq -r '.version' "$SNAPCRAFT_FILE")" = "$FNM_VERSION"
+          test "$(yq -r '.grade' "$SNAPCRAFT_FILE")" = "$FNM_GRADE"
+
+
+          echo "Save variables to output"
+          echo "fnm_version=$FNM_VERSION" >> "$GITHUB_OUTPUT"
+          echo "fnm_grade=$FNM_GRADE" >> "$GITHUB_OUTPUT"
+          echo "fnm_channel=$FNM_CHANNEL" >> "$GITHUB_OUTPUT"
+          echo "fnm_publishable=$FNM_PUBLISHABLE" >> "$GITHUB_OUTPUT"
+
           echo "FNM_VERSION=$FNM_VERSION" >> "$GITHUB_ENV"
+          echo "\n\n OUR $SNAPCRAFT_FILE:"
           cat "$SNAPCRAFT_FILE"
 
       - name: Build snap
+        id: build
         run: |
             set -eux
 
@@ -72,14 +107,55 @@ jobs:
 
             FNM_SNAP_PATH="$(ls -1 "$PWD"/fastnetmon-community_*.snap | tail -n1)"
             FNM_SNAP_FILE="$(basename "$FNM_SNAP_PATH")"
+            FNM_ARTIFACT_NAME="fastnetmon-community-snap"
+
+            sudo chown "$USER:$USER" "$FNM_SNAP_PATH"
+
 
             echo "FNM_SNAP_PATH=$FNM_SNAP_PATH" >> "$GITHUB_ENV"
             echo "FNM_SNAP_FILE=$FNM_SNAP_FILE" >> "$GITHUB_ENV"
+            echo "FNM_ARTIFACT_NAME=$FNM_ARTIFACT_NAME" >> "$GITHUB_ENV"
+
+            echo "fnm_snap_file=$FNM_SNAP_FILE" >> "$GITHUB_OUTPUT"
+            echo "fnm_artifact_name=$FNM_ARTIFACT_NAME" >> "$GITHUB_OUTPUT"
 
             ls -lah "$FNM_SNAP_PATH"
 
+      - name: Upload temporary snap artifact
+        id: upload
+        uses: actions/upload-artifact@v6
+        with:
+          name: ${{ steps.build.outputs.fnm_artifact_name }}
+          path: ${{ env.FNM_SNAP_PATH }}
+          retention-days: 1
 
+  test_snap_and_publish:
+    runs-on: ubuntu-24.04
+    needs:
+      - build_snap
+    steps:
+      - name: Download snap artifact
+        uses: actions/download-artifact@v6
+        with:
+          name: ${{ needs.build_snap.outputs.fnm_artifact_name }}
+          path: ./artifact
+      - name: Locate downloaded snap
+        run: |
+          set -eux
 
+          FNM_SNAP_FILE="${{ needs.build_snap.outputs.fnm_snap_file }}"
+          FNM_SNAP_PATH="$PWD/artifact/$FNM_SNAP_FILE"
+
+          test -f "$FNM_SNAP_PATH"
+
+          echo "FNM_SNAP_FILE=$FNM_SNAP_FILE" >> "$GITHUB_ENV"
+          echo "FNM_SNAP_PATH=$FNM_SNAP_PATH" >> "$GITHUB_ENV"
+
+          ls -lah "$FNM_SNAP_PATH"
+      
+      - name: Install tools
+        run: |
+          sudo snap install snapcraft --classic
       - name: Install local snap
         run: |
           sudo snap install "$FNM_SNAP_PATH" --dangerous --classic
@@ -103,3 +179,58 @@ jobs:
 
           echo -e "\n\nsnap services fastnetmon-community"
           snap services fastnetmon-community
+
+      - name: Check runtime libraries
+        run: |
+          set -eux
+
+          sudo snap run --shell fastnetmon-community.fastnetmon -c '
+            set -eu
+
+            ldd "$SNAP/usr/sbin/fastnetmon" | tee /tmp/ldd-fastnetmon.txt
+
+            if grep "not found" /tmp/ldd-fastnetmon.txt; then
+              echo "Some runtime libraries for fastnetmon are missing" >&2
+              exit 1
+            fi
+
+            ldd "$SNAP/usr/bin/fastnetmon_client" | tee /tmp/ldd-fastnetmon_client.txt
+
+            if grep "not found" /tmp/ldd-fastnetmon_client.txt; then
+              echo "Some runtime libraries for fastnetmon_client are missing" >&2
+              exit 1
+            fi
+          '
+      - name: Upload to Snap Store
+        if: needs.build_snap.outputs.fnm_publishable == 'true'
+        env:
+          SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_STORE_CREDENTIALS }}
+          FNM_CHANNEL: ${{ needs.build_snap.outputs.fnm_channel }}
+        run: |
+          set -eux
+
+          test -n "$FNM_CHANNEL"
+          snapcraft upload "$FNM_SNAP_PATH" --release="$FNM_CHANNEL"
+        
+  cleanup_artifact:
+    runs-on: ubuntu-24.04
+    needs:
+      - build_snap
+      - test_snap_and_publish
+
+    if: always() && needs.build_snap.outputs.fnm_artifact_id != ''
+
+    steps:
+      - name: Delete temporary artifact
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          ARTIFACT_ID: ${{ needs.build_snap.outputs.fnm_artifact_id }}
+        run: |
+          set -eux
+
+          test -n "$ARTIFACT_ID"
+
+          gh api \
+            --method DELETE \
+            "/repos/$REPO/actions/artifacts/$ARTIFACT_ID"


### PR DESCRIPTION
Remade test to separate runner (so we not affected by "trash" and libraries from `snapcraft pack  --destructive-mode`.
Add publish snap and clean artifact.