### PR TITLE
Flowspec improvements

### DIFF
--- a/src/bgp_protocol_flow_spec.cpp
+++ b/src/bgp_protocol_flow_spec.cpp
@@ -285,6 +285,32 @@ std::vector<dynamic_binary_buffer_t> build_attributes_for_flowspec_announce(flow
                                                  extended_attributes_as_binary_array };
 }
 
+static void encode_flow_spec_port_component(const std::vector<uint16_t>& ports,
+                                            FLOW_SPEC_ENTITY_TYPES component_type,
+                                            dynamic_binary_buffer_t& mp_nlri_flow_spec) {
+    if (ports.empty()) {
+        return;
+    }
+
+    mp_nlri_flow_spec.append_byte(component_type);
+
+    for (auto itr = ports.begin(); itr != ports.end(); ++itr) {
+        bgp_flow_spec_operator_byte_t operator_byte;
+        operator_byte.set_length_in_bytes(sizeof(*itr));
+
+        // We support only equal operations.
+        operator_byte.set_equal_bit();
+
+        if (std::distance(itr, ports.end()) == 1) {
+            operator_byte.set_end_of_list_bit();
+        }
+
+        mp_nlri_flow_spec.append_data_as_object_ptr(&operator_byte);
+        uint16_t port = htons(*itr);
+        mp_nlri_flow_spec.append_data_as_object_ptr(&port);
+    }
+}
+
 // Encode flow spec elements into MP NLRI
 bool encode_bgp_flow_spec_elements_as_mp_nlri(const flow_spec_rule_t& flow_spec_rule, dynamic_binary_buffer_t& mp_nlri_flow_spec) {
     mp_nlri_flow_spec.set_buffer_size_in_bytes(2048);
@@ -357,81 +383,9 @@ bool encode_bgp_flow_spec_elements_as_mp_nlri(const flow_spec_rule_t& flow_spec_
         }
     }
 
-    if (flow_spec_rule.ports.size() > 0) {
-        logger << log4cpp::Priority::DEBUG << "Encode flow spec attribute ports";
-
-        mp_nlri_flow_spec.append_byte(FLOW_SPEC_ENTITY_PORT);
-
-        for (auto itr = flow_spec_rule.ports.begin(); itr != flow_spec_rule.ports.end(); ++itr) {
-            bgp_flow_spec_operator_byte_t bgp_flow_spec_operator_byte;
-            bgp_flow_spec_operator_byte.set_length_in_bytes(sizeof(*itr));
-            bgp_flow_spec_operator_byte.set_equal_bit();
-
-            if (std::distance(itr, flow_spec_rule.ports.end()) == 1) {
-                bgp_flow_spec_operator_byte.set_end_of_list_bit();
-            }
-
-            mp_nlri_flow_spec.append_data_as_object_ptr(&bgp_flow_spec_operator_byte);
-            uint16_t port = htons(*itr);
-            mp_nlri_flow_spec.append_data_as_object_ptr(&port);
-        }
-    }
-
-    if (flow_spec_rule.destination_ports.size() > 0) {
-        logger << log4cpp::Priority::DEBUG << "Encode flow spec attribute desination ports";
-
-        mp_nlri_flow_spec.append_byte(FLOW_SPEC_ENTITY_DESTINATION_PORT);
-
-        for (auto itr = flow_spec_rule.destination_ports.begin(); itr != flow_spec_rule.destination_ports.end(); ++itr) {
-            bgp_flow_spec_operator_byte_t bgp_flow_spec_operator_byte;
-
-            // In destination_ports we encode porn number with two bytes
-            // I have not reasons to reduce amount of data here
-            bgp_flow_spec_operator_byte.set_length_in_bytes(sizeof(*itr));
-
-            // We support only equal operations
-            bgp_flow_spec_operator_byte.set_equal_bit();
-
-            // It's it's last element set end bit
-            if (std::distance(itr, flow_spec_rule.destination_ports.end()) == 1) {
-                bgp_flow_spec_operator_byte.set_end_of_list_bit();
-            }
-
-            mp_nlri_flow_spec.append_data_as_object_ptr(&bgp_flow_spec_operator_byte);
-            uint16_t destination_port = *itr;
-            destination_port          = htons(destination_port);
-
-            mp_nlri_flow_spec.append_data_as_object_ptr(&destination_port);
-        }
-    }
-
-    if (flow_spec_rule.source_ports.size() > 0) {
-        logger << log4cpp::Priority::DEBUG << "Encode flow spec attribute source ports";
-
-        mp_nlri_flow_spec.append_byte(FLOW_SPEC_ENTITY_SOURCE_PORT);
-
-        for (auto itr = flow_spec_rule.source_ports.begin(); itr != flow_spec_rule.source_ports.end(); ++itr) {
-            bgp_flow_spec_operator_byte_t bgp_flow_spec_operator_byte;
-
-            // In source_ports we encode porn number with two bytes
-            // I have not reasons to reduce amount of data here
-            bgp_flow_spec_operator_byte.set_length_in_bytes(sizeof(*itr));
-
-            // We support only equal operations
-            bgp_flow_spec_operator_byte.set_equal_bit();
-
-            // It's it's last element set end bit
-            if (std::distance(itr, flow_spec_rule.source_ports.end()) == 1) {
-                bgp_flow_spec_operator_byte.set_end_of_list_bit();
-            }
-
-            mp_nlri_flow_spec.append_data_as_object_ptr(&bgp_flow_spec_operator_byte);
-            uint16_t source_port = *itr;
-            source_port          = htons(source_port);
-
-            mp_nlri_flow_spec.append_data_as_object_ptr(&source_port);
-        }
-    }
+    encode_flow_spec_port_component(flow_spec_rule.ports, FLOW_SPEC_ENTITY_PORT, mp_nlri_flow_spec);
+    encode_flow_spec_port_component(flow_spec_rule.destination_ports, FLOW_SPEC_ENTITY_DESTINATION_PORT, mp_nlri_flow_spec);
+    encode_flow_spec_port_component(flow_spec_rule.source_ports, FLOW_SPEC_ENTITY_SOURCE_PORT, mp_nlri_flow_spec);
 
     if (flow_spec_rule.tcp_flags.size() > 0) {
         logger << log4cpp::Priority::DEBUG << "Encode flow spec attribute TCP flags";
@@ -711,6 +665,32 @@ std::string get_flow_spec_type_name_by_number(uint8_t flow_spec_type) {
     }
 }
 
+using flow_spec_uint16_adder_t = void (flow_spec_rule_t::*)(uint16_t);
+
+static bool decode_flow_spec_uint16_component(uint8_t*& local_data_ptr,
+                                              uint8_t* packet_end,
+                                              flow_spec_rule_t& flow_spec_rule,
+                                              flow_spec_uint16_adder_t add_value,
+                                              const char* component_name) {
+    // Skip the component type.
+    local_data_ptr++;
+
+    uint32_t scanned_bytes = 0;
+    multiple_flow_spec_enumerable_items_t scanned_items;
+
+    if (!read_one_or_more_values_encoded_with_operator_byte(local_data_ptr, packet_end, scanned_bytes, scanned_items)) {
+        logger << log4cpp::Priority::WARN << "Could not decode " << component_name << " values";
+        return false;
+    }
+
+    for (const auto& extracted_item : scanned_items) {
+        (flow_spec_rule.*add_value)(extracted_item.two_byte_value);
+    }
+
+    local_data_ptr += scanned_bytes;
+    return true;
+}
+
 bool flow_spec_decode_nlri_value(uint8_t* data_ptr, uint32_t data_length, flow_spec_rule_t& flow_spec_rule) {
     // We make copy because we will change this value so often
     uint8_t* local_data_ptr = data_ptr;
@@ -828,22 +808,10 @@ bool flow_spec_decode_nlri_value(uint8_t* data_ptr, uint32_t data_length, flow_s
         } else if (current_type == FLOW_SPEC_ENTITY_PORT) {
             // RFC 8955 Section 4.2.2.4 applies this component to either the
             // source or destination transport port.
-            local_data_ptr++;
-
-            uint32_t scanned_bytes = 0;
-            multiple_flow_spec_enumerable_items_t scanned_items;
-            bool result = read_one_or_more_values_encoded_with_operator_byte(local_data_ptr, packet_end, scanned_bytes, scanned_items);
-
-            if (!result) {
-                logger << log4cpp::Priority::WARN << "Could not decode FLOW_SPEC_ENTITY_PORT values";
+            if (!decode_flow_spec_uint16_component(local_data_ptr, packet_end, flow_spec_rule, &flow_spec_rule_t::add_port,
+                                                   "FLOW_SPEC_ENTITY_PORT")) {
                 return false;
             }
-
-            for (const auto& extracted_item : scanned_items) {
-                flow_spec_rule.add_port(extracted_item.two_byte_value);
-            }
-
-            local_data_ptr += scanned_bytes;
         } else if (current_type == FLOW_SPEC_ENTITY_IP_PROTOCOL) {
             // Skip type field
             local_data_ptr++;
@@ -970,62 +938,23 @@ bool flow_spec_decode_nlri_value(uint8_t* data_ptr, uint32_t data_length, flow_s
             local_data_ptr += scanned_bytes;
 
         } else if (current_type == FLOW_SPEC_ENTITY_PACKET_LENGTH) {
-
-            // Skip type field
-            local_data_ptr++;
-
-            uint32_t scanned_bytes = 0;
-            multiple_flow_spec_enumerable_items_t scanned_items;
-            bool result = read_one_or_more_values_encoded_with_operator_byte(local_data_ptr, packet_end, scanned_bytes, scanned_items);
-
-            if (!result) {
-                logger << log4cpp::Priority::WARN << "read_one_or_more_values_encoded_with_operator_byte returned error but we may have some values parsed before issue happened";
+            if (!decode_flow_spec_uint16_component(local_data_ptr, packet_end, flow_spec_rule,
+                                                   &flow_spec_rule_t::add_packet_length,
+                                                   "FLOW_SPEC_ENTITY_PACKET_LENGTH")) {
                 return false;
             }
-
-            for (auto extracted_item : scanned_items) {
-                flow_spec_rule.add_packet_length(extracted_item.two_byte_value);
-            }
-
-            local_data_ptr += scanned_bytes;
-
         } else if (current_type == FLOW_SPEC_ENTITY_SOURCE_PORT) {
-            // Skip type field
-            local_data_ptr++;
-
-            uint32_t scanned_bytes = 0;
-            multiple_flow_spec_enumerable_items_t scanned_items;
-            bool result = read_one_or_more_values_encoded_with_operator_byte(local_data_ptr, packet_end, scanned_bytes, scanned_items);
-
-            if (!result) {
-                logger << log4cpp::Priority::WARN << "read_one_or_more_values_encoded_with_operator_byte returned error but we may have some values parsed before issue happened";
+            if (!decode_flow_spec_uint16_component(local_data_ptr, packet_end, flow_spec_rule,
+                                                   &flow_spec_rule_t::add_source_port,
+                                                   "FLOW_SPEC_ENTITY_SOURCE_PORT")) {
                 return false;
             }
-
-            for (auto extracted_item : scanned_items) {
-                flow_spec_rule.add_source_port(extracted_item.two_byte_value);
-            }
-
-            local_data_ptr += scanned_bytes;
         } else if (current_type == FLOW_SPEC_ENTITY_DESTINATION_PORT) {
-
-            // Skip type field
-            local_data_ptr++;
-
-            uint32_t scanned_bytes = 0;
-            multiple_flow_spec_enumerable_items_t scanned_items;
-            bool result = read_one_or_more_values_encoded_with_operator_byte(local_data_ptr, packet_end, scanned_bytes, scanned_items);
-
-            if (!result) {
-                logger << log4cpp::Priority::WARN << "read_one_or_more_values_encoded_with_operator_byte returned error but we may have some values parsed before issue happened";
+            if (!decode_flow_spec_uint16_component(local_data_ptr, packet_end, flow_spec_rule,
+                                                   &flow_spec_rule_t::add_destination_port,
+                                                   "FLOW_SPEC_ENTITY_DESTINATION_PORT")) {
                 return false;
             }
-
-            for (auto extracted_item : scanned_items) {
-                flow_spec_rule.add_destination_port(extracted_item.two_byte_value);
-            }
-
-            local_data_ptr += scanned_bytes;
         } else {
             logger << log4cpp::Priority::WARN << "We could not handle flow spec element type "
                    << uint32_t(*local_data_ptr) << " pretty type: " << get_flow_spec_type_name_by_number(*local_data_ptr);
@@ -1416,6 +1345,7 @@ bool operator==(const flow_spec_tcp_flagset_t& lhs, const flow_spec_tcp_flagset_
 {
   "source_prefix": "4.0.0.0\/24",
   "destination_prefix": "127.0.0.0\/24",
+  "ports": [ 443 ],
   "destination_ports": [ 80 ],
   "source_ports": [ 53, 5353 ],
   "packet_lengths": [ 777, 1122 ],
@@ -1437,6 +1367,35 @@ bool read_flow_spec_from_json_to_native_format(const std::string& json_encoded_f
         logger << log4cpp::Priority::ERROR << "Cannot decode Flow Spec rule from JSON: '" << json_encoded_flow_spec << "'";
         return false;
     }
+
+    auto read_ports = [&](const char* field_name, flow_spec_uint16_adder_t add_port) -> bool {
+        if (!json_doc.contains(field_name)) {
+            return true;
+        }
+
+        std::vector<int32_t> ports_vector_as_ints;
+
+        try {
+            ports_vector_as_ints = json_doc[field_name].get<std::vector<int32_t>>();
+        } catch (nlohmann::json::exception& e) {
+            logger << log4cpp::Priority::ERROR << "Could not decode " << field_name << " " << e.what();
+            return false;
+        } catch (...) {
+            logger << log4cpp::Priority::ERROR << "Could not decode " << field_name;
+            return false;
+        }
+
+        for (auto port : ports_vector_as_ints) {
+            if (!valid_port(port)) {
+                logger << log4cpp::Priority::ERROR << "Could not parse " << field_name << " element: bad range " << port;
+                return false;
+            }
+
+            (flow_spec_rule.*add_port)(port);
+        }
+
+        return true;
+    };
 
     if (json_doc.contains("source_prefix")) {
         std::string source_prefix_string;
@@ -1508,73 +1467,10 @@ bool read_flow_spec_from_json_to_native_format(const std::string& json_encoded_f
         }
     }
 
-    if (json_doc.contains("destination_ports")) {
-        std::vector<int32_t> ports_vector_as_ints;
-
-        try {
-            ports_vector_as_ints = json_doc["destination_ports"].get<std::vector<int32_t>>();
-        } catch (nlohmann::json::exception& e) {
-            logger << log4cpp::Priority::ERROR << "Could not decode destination_ports " << e.what();
-            return false;
-        } catch (...) {
-            logger << log4cpp::Priority::ERROR << "Could not decode destination_ports";
-            return false;
-        }
-
-        for (auto port : ports_vector_as_ints) {
-            if (!valid_port(port)) {
-                logger << log4cpp::Priority::ERROR << "Could not parse destination_ports element: bad range " << port;
-                return false;
-            }
-
-            flow_spec_rule.add_destination_port(port);
-        }
-    }
-
-    if (json_doc.contains("ports")) {
-        std::vector<int32_t> ports_vector_as_ints;
-
-        try {
-            ports_vector_as_ints = json_doc["ports"].get<std::vector<int32_t>>();
-        } catch (nlohmann::json::exception& e) {
-            logger << log4cpp::Priority::ERROR << "Could not decode ports " << e.what();
-            return false;
-        } catch (...) {
-            logger << log4cpp::Priority::ERROR << "Could not decode ports";
-            return false;
-        }
-
-        for (auto port : ports_vector_as_ints) {
-            if (!valid_port(port)) {
-                logger << log4cpp::Priority::ERROR << "Could not parse ports element: bad range " << port;
-                return false;
-            }
-
-            flow_spec_rule.add_port(port);
-        }
-    }
-
-    if (json_doc.contains("source_ports")) {
-        std::vector<int32_t> ports_vector_as_ints;
-
-        try {
-            ports_vector_as_ints = json_doc["source_ports"].get<std::vector<int32_t>>();
-        } catch (nlohmann::json::exception& e) {
-            logger << log4cpp::Priority::ERROR << "Could not decode source_ports " << e.what();
-            return false;
-        } catch (...) {
-            logger << log4cpp::Priority::ERROR << "Could not decode source_ports";
-            return false;
-        }
-
-        for (auto port : ports_vector_as_ints) {
-            if (!valid_port(port)) {
-                logger << log4cpp::Priority::ERROR << "Could not parse source_ports element: bad range " << port;
-                return false;
-            }
-
-            flow_spec_rule.add_source_port(port);
-        }
+    if (!read_ports("ports", &flow_spec_rule_t::add_port) ||
+        !read_ports("destination_ports", &flow_spec_rule_t::add_destination_port) ||
+        !read_ports("source_ports", &flow_spec_rule_t::add_source_port)) {
+        return false;
     }
 
     if (json_doc.contains("packet_lengths")) {

--- a/src/bgp_protocol_flow_spec.cpp
+++ b/src/bgp_protocol_flow_spec.cpp
@@ -47,6 +47,14 @@ void uint8t_representation_of_tcp_flags_to_flow_spec(uint8_t tcp_flags, flow_spe
     if (extract_bit_value(tcp_flags, TCP_URG_FLAG_SHIFT)) {
         flagset.urg_flag = true;
     }
+
+    if (extract_bit_value(tcp_flags, 7)) {
+        flagset.ece_flag = true;
+    }
+
+    if (extract_bit_value(tcp_flags, 8)) {
+        flagset.cwr_flag = true;
+    }
 }
 
 bool decode_native_flow_spec_announce_from_binary_encoded_atributes(std::vector<dynamic_binary_buffer_t> binary_attributes,
@@ -453,7 +461,8 @@ bool encode_bgp_flow_spec_elements_as_mp_nlri(const flow_spec_rule_t& flow_spec_
 
         for (auto itr = flow_spec_rule.tcp_flags.begin(); itr != flow_spec_rule.tcp_flags.end(); ++itr) {
             bgp_flow_spec_bitmask_operator_byte_t bgp_flow_spec_operator_byte_tcp_flags;
-            bgp_flow_spec_operator_byte_tcp_flags.set_length_in_bytes(sizeof(bgp_flowspec_one_byte_byte_encoded_tcp_flags_t));
+            const bool needs_two_octets = itr->ns_flag;
+            bgp_flow_spec_operator_byte_tcp_flags.set_length_in_bytes(needs_two_octets ? 2 : 1);
 
             if (std::distance(itr, flow_spec_rule.tcp_flags.end()) == 1) {
                 bgp_flow_spec_operator_byte_tcp_flags.set_end_of_list_bit();
@@ -471,10 +480,17 @@ bool encode_bgp_flow_spec_elements_as_mp_nlri(const flow_spec_rule_t& flow_spec_
                 return false;
             }
 
-            bgp_flowspec_one_byte_byte_encoded_tcp_flags_t bgp_flowspec_one_byte_byte_encoded_tcp_flags =
-                return_in_one_byte_encoding(*itr);
+            bgp_flowspec_one_byte_byte_encoded_tcp_flags_t one_byte_flags = return_in_one_byte_encoding(*itr);
 
-            mp_nlri_flow_spec.append_data_as_object_ptr(&bgp_flowspec_one_byte_byte_encoded_tcp_flags);
+            if (needs_two_octets) {
+                uint8_t one_byte_flags_value = 0;
+                memcpy(&one_byte_flags_value, &one_byte_flags, sizeof(one_byte_flags_value));
+                uint16_t two_byte_flags = 0x0100 | one_byte_flags_value;
+                two_byte_flags          = htons(two_byte_flags);
+                mp_nlri_flow_spec.append_data_as_object_ptr(&two_byte_flags);
+            } else {
+                mp_nlri_flow_spec.append_data_as_object_ptr(&one_byte_flags);
+            }
         }
     }
 
@@ -941,8 +957,8 @@ bool flow_spec_decode_nlri_value(uint8_t* data_ptr, uint32_t data_length, flow_s
             }
 
             for (auto extracted_item : scanned_items) {
-                if (extracted_item.value_length != 1) {
-                    logger << log4cpp::Priority::WARN << "We do not support two byte encoded tcp fields";
+                if (extracted_item.value_length != 1 && extracted_item.value_length != 2) {
+                    logger << log4cpp::Priority::WARN << "TCP flags must use a one- or two-octet bitmask";
                     return false;
                 }
 
@@ -951,12 +967,17 @@ bool flow_spec_decode_nlri_value(uint8_t* data_ptr, uint32_t data_length, flow_s
                 // encoded tcp
                 // option field"         ;
 
-                bgp_flowspec_one_byte_byte_encoded_tcp_flags_t* bgp_flowspec_one_byte_byte_encoded_tcp_flags =
-                    (bgp_flowspec_one_byte_byte_encoded_tcp_flags_t*)&extracted_item.one_byte_value;
+                uint8_t tcp_control_bits = uint8_t(extracted_item.two_byte_value);
+                bgp_flowspec_one_byte_byte_encoded_tcp_flags_t bgp_flowspec_one_byte_byte_encoded_tcp_flags{};
+                memcpy(&bgp_flowspec_one_byte_byte_encoded_tcp_flags, &tcp_control_bits, sizeof(tcp_control_bits));
 
-                // logger << log4cpp::Priority::WARN << bgp_flowspec_one_byte_byte_encoded_tcp_flags->print();
+                // logger << log4cpp::Priority::WARN << bgp_flowspec_one_byte_byte_encoded_tcp_flags.print();
 
-                auto flagset = convert_one_byte_encoding_to_flowset(*bgp_flowspec_one_byte_byte_encoded_tcp_flags);
+                auto flagset = convert_one_byte_encoding_to_flowset(bgp_flowspec_one_byte_byte_encoded_tcp_flags);
+
+                if (extracted_item.value_length == 2 && (extracted_item.two_byte_value & 0x0100) != 0) {
+                    flagset.ns_flag = true;
+                }
 
                 if (flagset.we_have_least_one_flag_enabled()) {
                     flow_spec_rule.add_tcp_flagset(flagset);
@@ -1127,6 +1148,7 @@ bool read_one_or_more_values_encoded_with_operator_byte(uint8_t* start,
 
             // TODO: not sure about it? We really need it?
             element.two_byte_value = ntohs(element.two_byte_value);
+            element.value_length   = 2;
             element.operator_byte  = *bgp_flow_spec_operator_byte;
 
             multiple_flow_spec_enumerable_items.push_back(element);
@@ -1247,6 +1269,12 @@ bool read_flow_spec_tcp_flags_from_strig(const std::string& string_form, flow_sp
             flagset.psh_flag = true;
         } else if (tcp_flag_string == "rst") {
             flagset.rst_flag = true;
+        } else if (tcp_flag_string == "ece") {
+            flagset.ece_flag = true;
+        } else if (tcp_flag_string == "cwr") {
+            flagset.cwr_flag = true;
+        } else if (tcp_flag_string == "ns") {
+            flagset.ns_flag = true;
         } else {
             return false;
         }
@@ -1280,6 +1308,18 @@ std::string flow_spec_tcp_flagset_to_string(flow_spec_tcp_flagset_t const& tcp_f
 
     if (tcp_flagset.psh_flag) {
         output.push_back("push");
+    }
+
+    if (tcp_flagset.ece_flag) {
+        output.push_back("ece");
+    }
+
+    if (tcp_flagset.cwr_flag) {
+        output.push_back("cwr");
+    }
+
+    if (tcp_flagset.ns_flag) {
+        output.push_back("ns");
     }
 
     return boost::algorithm::join(output, "|");
@@ -1442,7 +1482,8 @@ bool operator!=(const flow_spec_tcp_flagset_t& lhs, const flow_spec_tcp_flagset_
 
 bool operator==(const flow_spec_tcp_flagset_t& lhs, const flow_spec_tcp_flagset_t& rhs) {
     if (lhs.syn_flag == rhs.syn_flag && lhs.ack_flag == rhs.ack_flag && lhs.rst_flag == rhs.rst_flag &&
-        lhs.psh_flag == rhs.psh_flag && lhs.urg_flag == rhs.urg_flag && lhs.fin_flag == rhs.fin_flag) {
+        lhs.psh_flag == rhs.psh_flag && lhs.urg_flag == rhs.urg_flag && lhs.fin_flag == rhs.fin_flag &&
+        lhs.ece_flag == rhs.ece_flag && lhs.cwr_flag == rhs.cwr_flag && lhs.ns_flag == rhs.ns_flag) {
         return true;
     } else {
         return false;
@@ -2254,11 +2295,19 @@ bgp_flowspec_one_byte_byte_encoded_tcp_flags_t return_in_one_byte_encoding(const
         one_byte_flags.rst = 1;
     }
 
+    if (flagset.ece_flag) {
+        one_byte_flags.ece = 1;
+    }
+
+    if (flagset.cwr_flag) {
+        one_byte_flags.cwr = 1;
+    }
+
     return one_byte_flags;
 }
 
 flow_spec_tcp_flagset_t convert_one_byte_encoding_to_flowset(const bgp_flowspec_one_byte_byte_encoded_tcp_flags_t& one_byte_flags) {
-    flow_spec_tcp_flagset_t flagset;
+    flow_spec_tcp_flagset_t flagset{};
 
     if (one_byte_flags.syn == 1) {
         flagset.syn_flag = true;
@@ -2283,6 +2332,14 @@ flow_spec_tcp_flagset_t convert_one_byte_encoding_to_flowset(const bgp_flowspec_
 
     if (one_byte_flags.rst == 1) {
         flagset.rst_flag = true;
+    }
+
+    if (one_byte_flags.ece == 1) {
+        flagset.ece_flag = true;
+    }
+
+    if (one_byte_flags.cwr == 1) {
+        flagset.cwr_flag = true;
     }
 
     return flagset;

--- a/src/bgp_protocol_flow_spec.cpp
+++ b/src/bgp_protocol_flow_spec.cpp
@@ -582,34 +582,60 @@ bool encode_bgp_flow_spec_elements_into_bgp_mp_attribute(const flow_spec_rule_t&
         return false;
     }
 
-    uint8_t nlri_length = mp_nlri_binary_buffer.get_used_size();
+    const size_t nlri_length = mp_nlri_binary_buffer.get_used_size();
 
-    if (nlri_length >= 240) {
-        logger << log4cpp::Priority::WARN << "We should encode length in two bytes";
+    // RFC 8955 Section 4.1 reserves the one-octet form for lengths below 240
+    // and uses a two-octet 0xfnnn encoding for lengths up to 4095.
+    if (nlri_length > 0x0fff) {
+        logger << log4cpp::Priority::WARN << "Flow Spec NLRI length exceeds the 12-bit encoding limit";
         return false;
     }
 
-    logger << log4cpp::Priority::DEBUG << "Encoded flow spec elements as MP Reach NLRI with size: " << int(nlri_length);
+    const bool use_extended_nlri_length = nlri_length >= 240;
+    const size_t nlri_length_field_size = use_extended_nlri_length ? 2 : 1;
+    const size_t attribute_value_length =
+        sizeof(bgp_mp_ext_flow_spec_header_t) + nlri_length_field_size + nlri_length;
+
+    logger << log4cpp::Priority::DEBUG << "Encoded flow spec elements as MP Reach NLRI with size: " << nlri_length;
 
     bgp_attribute_multiprotocol_extensions_t bgp_attribute_multiprotocol_extensions;
-    bgp_attribute_multiprotocol_extensions.attribute_length =
-        sizeof(bgp_mp_ext_flow_spec_header_t) + sizeof(nlri_length) + mp_nlri_binary_buffer.get_used_size();
+    const bool use_extended_attribute_length = attribute_value_length > UINT8_MAX;
+    bgp_attribute_multiprotocol_extensions.attribute_flags.set_extended_length_bit(use_extended_attribute_length);
 
-    logger << log4cpp::Priority::DEBUG
-           << "BGP MP reach attribute length: " << int(bgp_attribute_multiprotocol_extensions.attribute_length);
+    logger << log4cpp::Priority::DEBUG << "BGP MP reach attribute length: " << attribute_value_length;
     // Prepare flow spec MP Extenstion attribute
-    bgp_mp_ext_flow_spec_header_as_binary_array.set_buffer_size_in_bytes(2048);
+    const size_t attribute_header_size = use_extended_attribute_length ? 4 : 3;
+    bgp_mp_ext_flow_spec_header_as_binary_array.set_buffer_size_in_bytes(
+        (add_preamble ? attribute_header_size + sizeof(bgp_mp_ext_flow_spec_header_t) : 0) + nlri_length_field_size + nlri_length);
 
     bgp_mp_ext_flow_spec_header_t bgp_mp_ext_flow_spec_header;
     bgp_mp_ext_flow_spec_header.host_byte_order_to_network_byte_order();
 
     // For one very special GoBGP specific encoding we need capability to strip these fields
     if (add_preamble) {
-        bgp_mp_ext_flow_spec_header_as_binary_array.append_data_as_object_ptr(&bgp_attribute_multiprotocol_extensions);
+        if (use_extended_attribute_length) {
+            bgp_mp_ext_flow_spec_header_as_binary_array.append_data_as_object_ptr(
+                &bgp_attribute_multiprotocol_extensions.attribute_flags);
+            bgp_mp_ext_flow_spec_header_as_binary_array.append_data_as_object_ptr(
+                &bgp_attribute_multiprotocol_extensions.attribute_type);
+
+            uint16_t extended_attribute_length = htons(uint16_t(attribute_value_length));
+            bgp_mp_ext_flow_spec_header_as_binary_array.append_data_as_object_ptr(&extended_attribute_length);
+        } else {
+            bgp_attribute_multiprotocol_extensions.attribute_length = uint8_t(attribute_value_length);
+            bgp_mp_ext_flow_spec_header_as_binary_array.append_data_as_object_ptr(&bgp_attribute_multiprotocol_extensions);
+        }
+
         bgp_mp_ext_flow_spec_header_as_binary_array.append_data_as_object_ptr(&bgp_mp_ext_flow_spec_header);
     }
 
-    bgp_mp_ext_flow_spec_header_as_binary_array.append_data_as_object_ptr(&nlri_length);
+    if (use_extended_nlri_length) {
+        const uint16_t extended_nlri_length = htons(uint16_t(0xf000 | nlri_length));
+        bgp_mp_ext_flow_spec_header_as_binary_array.append_data_as_object_ptr(&extended_nlri_length);
+    } else {
+        bgp_mp_ext_flow_spec_header_as_binary_array.append_byte(uint8_t(nlri_length));
+    }
+
     bgp_mp_ext_flow_spec_header_as_binary_array.append_dynamic_buffer(mp_nlri_binary_buffer);
 
     if (bgp_mp_ext_flow_spec_header_as_binary_array.is_failed()) {

--- a/src/bgp_protocol_flow_spec.cpp
+++ b/src/bgp_protocol_flow_spec.cpp
@@ -357,6 +357,26 @@ bool encode_bgp_flow_spec_elements_as_mp_nlri(const flow_spec_rule_t& flow_spec_
         }
     }
 
+    if (flow_spec_rule.ports.size() > 0) {
+        logger << log4cpp::Priority::DEBUG << "Encode flow spec attribute ports";
+
+        mp_nlri_flow_spec.append_byte(FLOW_SPEC_ENTITY_PORT);
+
+        for (auto itr = flow_spec_rule.ports.begin(); itr != flow_spec_rule.ports.end(); ++itr) {
+            bgp_flow_spec_operator_byte_t bgp_flow_spec_operator_byte;
+            bgp_flow_spec_operator_byte.set_length_in_bytes(sizeof(*itr));
+            bgp_flow_spec_operator_byte.set_equal_bit();
+
+            if (std::distance(itr, flow_spec_rule.ports.end()) == 1) {
+                bgp_flow_spec_operator_byte.set_end_of_list_bit();
+            }
+
+            mp_nlri_flow_spec.append_data_as_object_ptr(&bgp_flow_spec_operator_byte);
+            uint16_t port = htons(*itr);
+            mp_nlri_flow_spec.append_data_as_object_ptr(&port);
+        }
+    }
+
     if (flow_spec_rule.destination_ports.size() > 0) {
         logger << log4cpp::Priority::DEBUG << "Encode flow spec attribute desination ports";
 
@@ -806,11 +826,24 @@ bool flow_spec_decode_nlri_value(uint8_t* data_ptr, uint32_t data_length, flow_s
             // Move forward on length of read prefix
             local_data_ptr += parsed_nlri_length;
         } else if (current_type == FLOW_SPEC_ENTITY_PORT) {
-            // Different type of port's
-            if (current_type == FLOW_SPEC_ENTITY_PORT) {
-                logger << log4cpp::Priority::WARN << "We do not support common ports";
+            // RFC 8955 Section 4.2.2.4 applies this component to either the
+            // source or destination transport port.
+            local_data_ptr++;
+
+            uint32_t scanned_bytes = 0;
+            multiple_flow_spec_enumerable_items_t scanned_items;
+            bool result = read_one_or_more_values_encoded_with_operator_byte(local_data_ptr, packet_end, scanned_bytes, scanned_items);
+
+            if (!result) {
+                logger << log4cpp::Priority::WARN << "Could not decode FLOW_SPEC_ENTITY_PORT values";
                 return false;
             }
+
+            for (const auto& extracted_item : scanned_items) {
+                flow_spec_rule.add_port(extracted_item.two_byte_value);
+            }
+
+            local_data_ptr += scanned_bytes;
         } else if (current_type == FLOW_SPEC_ENTITY_IP_PROTOCOL) {
             // Skip type field
             local_data_ptr++;
@@ -1305,6 +1338,10 @@ bool operator==(const flow_spec_rule_t& lhs, const flow_spec_rule_t& rhs) {
         return false;
     }
 
+    if (lhs.ports != rhs.ports) {
+        return false;
+    }
+
     if (lhs.packet_lengths != rhs.packet_lengths) {
         return false;
     }
@@ -1491,6 +1528,29 @@ bool read_flow_spec_from_json_to_native_format(const std::string& json_encoded_f
             }
 
             flow_spec_rule.add_destination_port(port);
+        }
+    }
+
+    if (json_doc.contains("ports")) {
+        std::vector<int32_t> ports_vector_as_ints;
+
+        try {
+            ports_vector_as_ints = json_doc["ports"].get<std::vector<int32_t>>();
+        } catch (nlohmann::json::exception& e) {
+            logger << log4cpp::Priority::ERROR << "Could not decode ports " << e.what();
+            return false;
+        } catch (...) {
+            logger << log4cpp::Priority::ERROR << "Could not decode ports";
+            return false;
+        }
+
+        for (auto port : ports_vector_as_ints) {
+            if (!valid_port(port)) {
+                logger << log4cpp::Priority::ERROR << "Could not parse ports element: bad range " << port;
+                return false;
+            }
+
+            flow_spec_rule.add_port(port);
         }
     }
 
@@ -1997,6 +2057,10 @@ bool encode_flow_spec_to_json_raw(const flow_spec_rule_t& flow_spec_rule, bool a
 
     if (!flow_spec_rule.destination_ports.empty()) {
         flow_json["destination_ports"] = flow_spec_rule.destination_ports;
+    }
+
+    if (!flow_spec_rule.ports.empty()) {
+        flow_json["ports"] = flow_spec_rule.ports;
     }
 
     if (!flow_spec_rule.source_ports.empty()) {

--- a/src/bgp_protocol_flow_spec.cpp
+++ b/src/bgp_protocol_flow_spec.cpp
@@ -311,6 +311,29 @@ static void encode_flow_spec_port_component(const std::vector<uint16_t>& ports,
     }
 }
 
+static void encode_flow_spec_uint8_component(const std::vector<uint8_t>& values,
+                                             FLOW_SPEC_ENTITY_TYPES component_type,
+                                             dynamic_binary_buffer_t& mp_nlri_flow_spec) {
+    if (values.empty()) {
+        return;
+    }
+
+    mp_nlri_flow_spec.append_byte(component_type);
+
+    for (auto itr = values.begin(); itr != values.end(); ++itr) {
+        bgp_flow_spec_operator_byte_t operator_byte;
+        operator_byte.set_length_in_bytes(sizeof(*itr));
+        operator_byte.set_equal_bit();
+
+        if (std::distance(itr, values.end()) == 1) {
+            operator_byte.set_end_of_list_bit();
+        }
+
+        mp_nlri_flow_spec.append_data_as_object_ptr(&operator_byte);
+        mp_nlri_flow_spec.append_byte(*itr);
+    }
+}
+
 // Encode flow spec elements into MP NLRI
 bool encode_bgp_flow_spec_elements_as_mp_nlri(const flow_spec_rule_t& flow_spec_rule, dynamic_binary_buffer_t& mp_nlri_flow_spec) {
     mp_nlri_flow_spec.set_buffer_size_in_bytes(2048);
@@ -386,6 +409,8 @@ bool encode_bgp_flow_spec_elements_as_mp_nlri(const flow_spec_rule_t& flow_spec_
     encode_flow_spec_port_component(flow_spec_rule.ports, FLOW_SPEC_ENTITY_PORT, mp_nlri_flow_spec);
     encode_flow_spec_port_component(flow_spec_rule.destination_ports, FLOW_SPEC_ENTITY_DESTINATION_PORT, mp_nlri_flow_spec);
     encode_flow_spec_port_component(flow_spec_rule.source_ports, FLOW_SPEC_ENTITY_SOURCE_PORT, mp_nlri_flow_spec);
+    encode_flow_spec_uint8_component(flow_spec_rule.icmp_types, FLOW_SPEC_ENTITY_ICMP_TYPE, mp_nlri_flow_spec);
+    encode_flow_spec_uint8_component(flow_spec_rule.icmp_codes, FLOW_SPEC_ENTITY_ICMP_CODE, mp_nlri_flow_spec);
 
     if (flow_spec_rule.tcp_flags.size() > 0) {
         logger << log4cpp::Priority::DEBUG << "Encode flow spec attribute TCP flags";
@@ -666,6 +691,7 @@ std::string get_flow_spec_type_name_by_number(uint8_t flow_spec_type) {
 }
 
 using flow_spec_uint16_adder_t = void (flow_spec_rule_t::*)(uint16_t);
+using flow_spec_uint8_adder_t  = void (flow_spec_rule_t::*)(uint8_t);
 
 static bool decode_flow_spec_uint16_component(uint8_t*& local_data_ptr,
                                               uint8_t* packet_end,
@@ -685,6 +711,34 @@ static bool decode_flow_spec_uint16_component(uint8_t*& local_data_ptr,
 
     for (const auto& extracted_item : scanned_items) {
         (flow_spec_rule.*add_value)(extracted_item.two_byte_value);
+    }
+
+    local_data_ptr += scanned_bytes;
+    return true;
+}
+
+static bool decode_flow_spec_uint8_component(uint8_t*& local_data_ptr,
+                                             uint8_t* packet_end,
+                                             flow_spec_rule_t& flow_spec_rule,
+                                             flow_spec_uint8_adder_t add_value,
+                                             const char* component_name) {
+    local_data_ptr++;
+
+    uint32_t scanned_bytes = 0;
+    multiple_flow_spec_enumerable_items_t scanned_items;
+
+    if (!read_one_or_more_values_encoded_with_operator_byte(local_data_ptr, packet_end, scanned_bytes, scanned_items)) {
+        logger << log4cpp::Priority::WARN << "Could not decode " << component_name << " values";
+        return false;
+    }
+
+    for (const auto& extracted_item : scanned_items) {
+        if (extracted_item.two_byte_value > 255) {
+            logger << log4cpp::Priority::WARN << component_name << " value exceeds 255";
+            return false;
+        }
+
+        (flow_spec_rule.*add_value)(uint8_t(extracted_item.two_byte_value));
     }
 
     local_data_ptr += scanned_bytes;
@@ -953,6 +1007,18 @@ bool flow_spec_decode_nlri_value(uint8_t* data_ptr, uint32_t data_length, flow_s
             if (!decode_flow_spec_uint16_component(local_data_ptr, packet_end, flow_spec_rule,
                                                    &flow_spec_rule_t::add_destination_port,
                                                    "FLOW_SPEC_ENTITY_DESTINATION_PORT")) {
+                return false;
+            }
+        } else if (current_type == FLOW_SPEC_ENTITY_ICMP_TYPE) {
+            if (!decode_flow_spec_uint8_component(local_data_ptr, packet_end, flow_spec_rule,
+                                                  &flow_spec_rule_t::add_icmp_type,
+                                                  "FLOW_SPEC_ENTITY_ICMP_TYPE")) {
+                return false;
+            }
+        } else if (current_type == FLOW_SPEC_ENTITY_ICMP_CODE) {
+            if (!decode_flow_spec_uint8_component(local_data_ptr, packet_end, flow_spec_rule,
+                                                  &flow_spec_rule_t::add_icmp_code,
+                                                  "FLOW_SPEC_ENTITY_ICMP_CODE")) {
                 return false;
             }
         } else {
@@ -1271,6 +1337,14 @@ bool operator==(const flow_spec_rule_t& lhs, const flow_spec_rule_t& rhs) {
         return false;
     }
 
+    if (lhs.icmp_types != rhs.icmp_types) {
+        return false;
+    }
+
+    if (lhs.icmp_codes != rhs.icmp_codes) {
+        return false;
+    }
+
     if (lhs.packet_lengths != rhs.packet_lengths) {
         return false;
     }
@@ -1348,6 +1422,8 @@ bool operator==(const flow_spec_tcp_flagset_t& lhs, const flow_spec_tcp_flagset_
   "ports": [ 443 ],
   "destination_ports": [ 80 ],
   "source_ports": [ 53, 5353 ],
+  "icmp_types": [ 8 ],
+  "icmp_codes": [ 0 ],
   "packet_lengths": [ 777, 1122 ],
   "protocols": [ "tcp" ],
   "fragmentation_flags":[ "is-fragment", "dont-fragment" ],
@@ -1392,6 +1468,35 @@ bool read_flow_spec_from_json_to_native_format(const std::string& json_encoded_f
             }
 
             (flow_spec_rule.*add_port)(port);
+        }
+
+        return true;
+    };
+
+    auto read_uint8_values = [&](const char* field_name, flow_spec_uint8_adder_t add_value) -> bool {
+        if (!json_doc.contains(field_name)) {
+            return true;
+        }
+
+        std::vector<int32_t> values;
+
+        try {
+            values = json_doc[field_name].get<std::vector<int32_t>>();
+        } catch (nlohmann::json::exception& e) {
+            logger << log4cpp::Priority::ERROR << "Could not decode " << field_name << " " << e.what();
+            return false;
+        } catch (...) {
+            logger << log4cpp::Priority::ERROR << "Could not decode " << field_name;
+            return false;
+        }
+
+        for (auto value : values) {
+            if (value < 0 || value > 255) {
+                logger << log4cpp::Priority::ERROR << "Could not parse " << field_name << " element: bad range " << value;
+                return false;
+            }
+
+            (flow_spec_rule.*add_value)(uint8_t(value));
         }
 
         return true;
@@ -1470,6 +1575,11 @@ bool read_flow_spec_from_json_to_native_format(const std::string& json_encoded_f
     if (!read_ports("ports", &flow_spec_rule_t::add_port) ||
         !read_ports("destination_ports", &flow_spec_rule_t::add_destination_port) ||
         !read_ports("source_ports", &flow_spec_rule_t::add_source_port)) {
+        return false;
+    }
+
+    if (!read_uint8_values("icmp_types", &flow_spec_rule_t::add_icmp_type) ||
+        !read_uint8_values("icmp_codes", &flow_spec_rule_t::add_icmp_code)) {
         return false;
     }
 
@@ -1961,6 +2071,14 @@ bool encode_flow_spec_to_json_raw(const flow_spec_rule_t& flow_spec_rule, bool a
 
     if (!flow_spec_rule.source_ports.empty()) {
         flow_json["source_ports"] = flow_spec_rule.source_ports;
+    }
+
+    if (!flow_spec_rule.icmp_types.empty()) {
+        flow_json["icmp_types"] = flow_spec_rule.icmp_types;
+    }
+
+    if (!flow_spec_rule.icmp_codes.empty()) {
+        flow_json["icmp_codes"] = flow_spec_rule.icmp_codes;
     }
 
     if (!flow_spec_rule.packet_lengths.empty()) {

--- a/src/bgp_protocol_flow_spec.cpp
+++ b/src/bgp_protocol_flow_spec.cpp
@@ -1121,9 +1121,9 @@ bool read_one_or_more_values_encoded_with_operator_byte(uint8_t* start,
                                                         uint8_t* packet_end,
                                                         uint32_t& readed_bytes,
                                                         multiple_flow_spec_enumerable_items_t& multiple_flow_spec_enumerable_items) {
-    // TODO: pretty danegrous idea to do infinite loop and we are using 100
-    // iterations here for
-    // worst case
+    // Bound the number of operands to limit work on hostile input. Reaching
+    // this cap without an end-of-list bit is malformed, not a partial success:
+    // otherwise the caller would interpret the next operator as a component type.
     uint8_t* local_data_ptr = start;
 
     for (int i = 0; i < 100; i++) {
@@ -1187,16 +1187,15 @@ bool read_one_or_more_values_encoded_with_operator_byte(uint8_t* start,
         // Shift pointer to next element
         local_data_ptr += sizeof(bgp_flow_spec_operator_byte_t) + bgp_flow_spec_operator_byte->get_value_length();
 
-        // If this was last lement in list just stop this loop
+        // A component ends only when an operator explicitly carries EOL.
         if (bgp_flow_spec_operator_byte->end_of_list == 1) {
-            break;
+            readed_bytes = local_data_ptr - start;
+            return true;
         }
     }
 
-    // Return number of scanned bytes
-    readed_bytes = local_data_ptr - start;
-
-    return true;
+    logger << log4cpp::Priority::WARN << "Flow Spec component exceeds 100 operands without an end-of-list bit";
+    return false;
 }
 
 bool read_flow_spec_fragmentation_types_from_string(const std::string& string_form, flow_spec_fragmentation_types_t& fragment_flag) {

--- a/src/bgp_protocol_flow_spec.cpp
+++ b/src/bgp_protocol_flow_spec.cpp
@@ -157,8 +157,14 @@ bool decode_native_flow_spec_announce_from_binary_encoded_atributes(std::vector<
             //        (uint8_t*)gobgp_lib_path->path_attributes[i]->value,
             //        gobgp_lib_path->path_attributes[i]->len) ;
 
+            if (bgp_attibute_common_header.attribute_value_length < sizeof(bgp_mp_ext_flow_spec_header_t) + 1) {
+                logger << log4cpp::Priority::WARN << "Flow Spec MP_REACH attribute is too short";
+                return false;
+            }
+
             uint8_t* flow_spec_attribute_shift =
                 (uint8_t*)binary_attribute.get_pointer() + bgp_attibute_common_header.attribute_body_shift;
+            uint8_t* flow_spec_attribute_end = flow_spec_attribute_shift + bgp_attibute_common_header.attribute_value_length;
 
             bgp_mp_ext_flow_spec_header_t* bgp_mp_ext_flow_spec_header = (bgp_mp_ext_flow_spec_header_t*)flow_spec_attribute_shift;
             bgp_mp_ext_flow_spec_header->network_to_host_byte_order();
@@ -171,6 +177,15 @@ bool decode_native_flow_spec_announce_from_binary_encoded_atributes(std::vector<
                 return false;
             }
 
+            // RFC 8955 requires FlowSpec advertisements to use a zero-length
+            // next hop. Reject a non-zero value instead of skipping it: apart
+            // from being non-compliant, accepting it would make the fixed
+            // header below interpret next-hop bytes as the NLRI length.
+            if (bgp_mp_ext_flow_spec_header->length_of_next_hop != 0) {
+                logger << log4cpp::Priority::WARN << "Flow Spec MP_REACH must use a zero-length next hop";
+                return false;
+            }
+
             uint8_t* flow_spec_types_shift = (uint8_t*)binary_attribute.get_pointer() + bgp_attibute_common_header.attribute_body_shift +
                                              sizeof(bgp_mp_ext_flow_spec_header_t);
 
@@ -179,17 +194,36 @@ bool decode_native_flow_spec_announce_from_binary_encoded_atributes(std::vector<
             uint16_t nlri_value_length           = 0;
             uint16_t nlri_length_of_length_field = 1;
 
-            // 240 is 0xf0
-            if (flow_spec_types_shift[0] < 240) {
+            // RFC 8955 Section 4.1 uses one octet below 240 and a 12-bit
+            // extended length with an 0xf high nibble for larger NLRIs.
+            if (flow_spec_types_shift[0] < 0xf0) {
                 nlri_value_length           = flow_spec_types_shift[0];
                 nlri_length_of_length_field = 1;
             } else {
                 nlri_length_of_length_field = 2;
-                logger << log4cpp::Priority::WARN << "We do not support for 2 byte NLRI length encoding yet";
+
+                if (flow_spec_attribute_end - flow_spec_types_shift < nlri_length_of_length_field) {
+                    logger << log4cpp::Priority::WARN << "Flow Spec NLRI is missing the second extended-length octet";
+                    return false;
+                }
+
+                nlri_value_length = uint16_t((uint16_t(flow_spec_types_shift[0] & 0x0f) << 8) | flow_spec_types_shift[1]);
+
+                if (nlri_value_length < 240) {
+                    logger << log4cpp::Priority::WARN << "Flow Spec NLRI uses extended encoding for a length below 240";
+                    return false;
+                }
+            }
+
+            const uint32_t available_nlri_bytes = flow_spec_attribute_end - flow_spec_types_shift;
+
+            if (uint32_t(nlri_length_of_length_field) + nlri_value_length > available_nlri_bytes) {
+                logger << log4cpp::Priority::WARN << "Flow Spec NLRI length " << nlri_value_length
+                       << " exceeds the " << available_nlri_bytes - nlri_length_of_length_field
+                       << " payload bytes available in MP_REACH";
                 return false;
             }
 
-            // TODO: add sanity checks for length
             // logger << log4cpp::Priority::WARN << "We have " <<
             // uint32_t(gobgp_lib_path->path_attributes[i]->len) << " byte length
             // attrinute" ;

--- a/src/bgp_protocol_flow_spec.hpp
+++ b/src/bgp_protocol_flow_spec.hpp
@@ -183,6 +183,10 @@ class flow_spec_rule_t {
         this->source_ports.push_back(source_port);
     }
 
+    void add_port(uint16_t port) {
+        this->ports.push_back(port);
+    }
+
     void add_destination_port(uint16_t destination_port) {
         this->destination_ports.push_back(destination_port);
     }
@@ -262,6 +266,7 @@ class flow_spec_rule_t {
 
         ar& BOOST_SERIALIZATION_NVP(source_ports);
         ar& BOOST_SERIALIZATION_NVP(destination_ports);
+        ar& BOOST_SERIALIZATION_NVP(ports);
         ar& BOOST_SERIALIZATION_NVP(packet_lengths);
         ar& BOOST_SERIALIZATION_NVP(vlans);
         ar& BOOST_SERIALIZATION_NVP(ttls);
@@ -305,6 +310,9 @@ class flow_spec_rule_t {
 
     std::vector<uint16_t> source_ports;
     std::vector<uint16_t> destination_ports;
+
+    // RFC 8955 type 4 ports match either the source or destination port.
+    std::vector<uint16_t> ports;
 
     // It's total IP packet length (excluding Layer 2 but including IP header)
     // https://datatracker.ietf.org/doc/html/rfc5575#section-4

--- a/src/bgp_protocol_flow_spec.hpp
+++ b/src/bgp_protocol_flow_spec.hpp
@@ -187,6 +187,14 @@ class flow_spec_rule_t {
         this->ports.push_back(port);
     }
 
+    void add_icmp_type(uint8_t icmp_type) {
+        this->icmp_types.push_back(icmp_type);
+    }
+
+    void add_icmp_code(uint8_t icmp_code) {
+        this->icmp_codes.push_back(icmp_code);
+    }
+
     void add_destination_port(uint16_t destination_port) {
         this->destination_ports.push_back(destination_port);
     }
@@ -267,6 +275,8 @@ class flow_spec_rule_t {
         ar& BOOST_SERIALIZATION_NVP(source_ports);
         ar& BOOST_SERIALIZATION_NVP(destination_ports);
         ar& BOOST_SERIALIZATION_NVP(ports);
+        ar& BOOST_SERIALIZATION_NVP(icmp_types);
+        ar& BOOST_SERIALIZATION_NVP(icmp_codes);
         ar& BOOST_SERIALIZATION_NVP(packet_lengths);
         ar& BOOST_SERIALIZATION_NVP(vlans);
         ar& BOOST_SERIALIZATION_NVP(ttls);
@@ -313,6 +323,9 @@ class flow_spec_rule_t {
 
     // RFC 8955 type 4 ports match either the source or destination port.
     std::vector<uint16_t> ports;
+
+    std::vector<uint8_t> icmp_types;
+    std::vector<uint8_t> icmp_codes;
 
     // It's total IP packet length (excluding Layer 2 but including IP header)
     // https://datatracker.ietf.org/doc/html/rfc5575#section-4

--- a/src/bgp_protocol_flow_spec.hpp
+++ b/src/bgp_protocol_flow_spec.hpp
@@ -33,10 +33,13 @@ class flow_spec_tcp_flagset_t {
     bool psh_flag = false;
     bool rst_flag = false;
     bool urg_flag = false;
+    bool ece_flag = false;
+    bool cwr_flag = false;
+    bool ns_flag  = false;
 
     // Do we have least one flag enabled?
     bool we_have_least_one_flag_enabled() const {
-        return syn_flag || fin_flag || urg_flag || ack_flag || psh_flag || rst_flag;
+        return syn_flag || fin_flag || urg_flag || ack_flag || psh_flag || rst_flag || ece_flag || cwr_flag || ns_flag;
     }
 
     std::string print() const {
@@ -47,7 +50,10 @@ class flow_spec_tcp_flagset_t {
                << "fin: " << fin_flag << " "
                << "psh: " << psh_flag << " "
                << "rst: " << rst_flag << " "
-               << "urg: " << urg_flag;
+               << "urg: " << urg_flag << " "
+               << "ece: " << ece_flag << " "
+               << "cwr: " << cwr_flag << " "
+               << "ns: " << ns_flag;
 
         return buffer.str();
     }
@@ -59,6 +65,9 @@ class flow_spec_tcp_flagset_t {
         ar& BOOST_SERIALIZATION_NVP(psh_flag);
         ar& BOOST_SERIALIZATION_NVP(rst_flag);
         ar& BOOST_SERIALIZATION_NVP(urg_flag);
+        ar& BOOST_SERIALIZATION_NVP(ece_flag);
+        ar& BOOST_SERIALIZATION_NVP(cwr_flag);
+        ar& BOOST_SERIALIZATION_NVP(ns_flag);
     }
 };
 

--- a/src/fastnetmon_simple_packet.hpp
+++ b/src/fastnetmon_simple_packet.hpp
@@ -92,11 +92,12 @@ class simple_packet_t {
     // Fragment offset in bytes when fragmentation involved
     uint16_t ip_fragment_offset = 0;
 
-    // ICMP type
+    // ICMP type and code may legitimately be zero. Keep presence separately so
+    // collectors which do not export them cannot accidentally match type/code 0.
     uint8_t icmp_type = 0;
-
-    // ICMP code
     uint8_t icmp_code = 0;
+    bool icmp_type_set = false;
+    bool icmp_code_set = false;
 
     // Time when we actually received this packet, we use quite rough and inaccurate but very fast time source for it
     time_t arrival_time = 0;

--- a/src/fastnetmon_simple_packet.hpp
+++ b/src/fastnetmon_simple_packet.hpp
@@ -75,6 +75,9 @@ class simple_packet_t {
     // TCP flags
     uint8_t flags = 0;
 
+    // TCP ECN nonce concealment protection flag from header octet 13.
+    bool tcp_ns = false;
+
     // TCP numbers
     uint32_t tcp_sequence_number = 0;
     uint32_t tcp_ack_number      = 0;

--- a/src/filter.cpp
+++ b/src/filter.cpp
@@ -22,6 +22,8 @@ bool filter_packet_by_flowspec_rule(const simple_packet_t& current_packet, const
     bool source_port_matches         = false;
     bool destination_port_matches    = false;
     bool port_matches                = false;
+    bool icmp_type_matches           = false;
+    bool icmp_code_matches           = false;
     bool source_ip_matches           = false;
     bool destination_ip_matches      = false;
     bool packet_size_matches         = false;
@@ -30,6 +32,8 @@ bool filter_packet_by_flowspec_rule(const simple_packet_t& current_packet, const
     bool fragmentation_flags_matches = false;
     bool protocol_matches            = false;
     const bool is_tcp_or_udp          = current_packet.protocol == IPPROTO_TCP || current_packet.protocol == IPPROTO_UDP;
+    const bool icmp_component_applies =
+        current_packet.protocol == IPPROTO_ICMP && current_packet.ip_fragment_offset == 0;
 
     if (flow_announce.source_ports.size() == 0) {
         source_port_matches = true;
@@ -59,6 +63,22 @@ bool filter_packet_by_flowspec_rule(const simple_packet_t& current_packet, const
                 std::find(flow_announce.ports.begin(), flow_announce.ports.end(), current_packet.destination_port) !=
                     flow_announce.ports.end())) {
         port_matches = true;
+    }
+
+    if (flow_announce.icmp_types.empty()) {
+        icmp_type_matches = true;
+    } else if (icmp_component_applies && current_packet.icmp_type_set &&
+               std::find(flow_announce.icmp_types.begin(), flow_announce.icmp_types.end(), current_packet.icmp_type) !=
+                   flow_announce.icmp_types.end()) {
+        icmp_type_matches = true;
+    }
+
+    if (flow_announce.icmp_codes.empty()) {
+        icmp_code_matches = true;
+    } else if (icmp_component_applies && current_packet.icmp_code_set &&
+               std::find(flow_announce.icmp_codes.begin(), flow_announce.icmp_codes.end(), current_packet.icmp_code) !=
+                   flow_announce.icmp_codes.end()) {
+        icmp_code_matches = true;
     }
 
     if (flow_announce.protocols.size() == 0) {
@@ -236,8 +256,9 @@ bool filter_packet_by_flowspec_rule(const simple_packet_t& current_packet, const
     */
 
     // Return true only of all parts matched
-    if (source_port_matches && destination_port_matches && port_matches && source_ip_matches && destination_ip_matches &&
-        packet_size_matches && tcp_flags_matches && fragmentation_flags_matches && protocol_matches && vlan_matches) {
+    if (source_port_matches && destination_port_matches && port_matches && icmp_type_matches && icmp_code_matches &&
+        source_ip_matches && destination_ip_matches && packet_size_matches && tcp_flags_matches &&
+        fragmentation_flags_matches && protocol_matches && vlan_matches) {
         return true;
     }
 

--- a/src/filter.cpp
+++ b/src/filter.cpp
@@ -21,6 +21,7 @@ bool filter_packet_by_flowspec_rule_list(const simple_packet_t& current_packet,
 bool filter_packet_by_flowspec_rule(const simple_packet_t& current_packet, const flow_spec_rule_t& flow_announce) {
     bool source_port_matches         = false;
     bool destination_port_matches    = false;
+    bool port_matches                = false;
     bool source_ip_matches           = false;
     bool destination_ip_matches      = false;
     bool packet_size_matches         = false;
@@ -47,6 +48,16 @@ bool filter_packet_by_flowspec_rule(const simple_packet_t& current_packet, const
             // We found this IP in list
             destination_port_matches = true;
         }
+    }
+
+    if (flow_announce.ports.size() == 0) {
+        port_matches = true;
+    } else if ((current_packet.protocol == IPPROTO_TCP || current_packet.protocol == IPPROTO_UDP) &&
+               (std::find(flow_announce.ports.begin(), flow_announce.ports.end(), current_packet.source_port) !=
+                    flow_announce.ports.end() ||
+                std::find(flow_announce.ports.begin(), flow_announce.ports.end(), current_packet.destination_port) !=
+                    flow_announce.ports.end())) {
+        port_matches = true;
     }
 
     if (flow_announce.protocols.size() == 0) {
@@ -224,7 +235,7 @@ bool filter_packet_by_flowspec_rule(const simple_packet_t& current_packet, const
     */
 
     // Return true only of all parts matched
-    if (source_port_matches && destination_port_matches && source_ip_matches && destination_ip_matches &&
+    if (source_port_matches && destination_port_matches && port_matches && source_ip_matches && destination_ip_matches &&
         packet_size_matches && tcp_flags_matches && fragmentation_flags_matches && protocol_matches && vlan_matches) {
         return true;
     }

--- a/src/filter.cpp
+++ b/src/filter.cpp
@@ -193,10 +193,11 @@ bool filter_packet_by_flowspec_rule(const simple_packet_t& current_packet, const
 
     if (flow_announce.tcp_flags.size() == 0) {
         tcp_flags_matches = true;
-    } else {
+    } else if (current_packet.protocol == IPPROTO_TCP && current_packet.ip_fragment_offset == 0) {
         // Convert 8bit representation of flags for this packet into flagset representation for flow spec
         flow_spec_tcp_flagset_t flagset;
         uint8t_representation_of_tcp_flags_to_flow_spec(current_packet.flags, flagset);
+        flagset.ns_flag = current_packet.tcp_ns;
 
         // logger << log4cpp::Priority::WARN <<"Packet's tcp flagset: " << flagset.to_string();
 

--- a/src/filter.cpp
+++ b/src/filter.cpp
@@ -31,13 +31,15 @@ bool filter_packet_by_flowspec_rule(const simple_packet_t& current_packet, const
     bool tcp_flags_matches           = false;
     bool fragmentation_flags_matches = false;
     bool protocol_matches            = false;
-    const bool is_tcp_or_udp          = current_packet.protocol == IPPROTO_TCP || current_packet.protocol == IPPROTO_UDP;
+    const bool port_component_applies =
+        (current_packet.protocol == IPPROTO_TCP || current_packet.protocol == IPPROTO_UDP) &&
+        current_packet.ip_fragment_offset == 0;
     const bool icmp_component_applies =
         current_packet.protocol == IPPROTO_ICMP && current_packet.ip_fragment_offset == 0;
 
     if (flow_announce.source_ports.size() == 0) {
         source_port_matches = true;
-    } else if (is_tcp_or_udp) {
+    } else if (port_component_applies) {
         if (std::find(flow_announce.source_ports.begin(), flow_announce.source_ports.end(), current_packet.source_port) !=
             flow_announce.source_ports.end()) {
             // We found this IP in list
@@ -47,7 +49,7 @@ bool filter_packet_by_flowspec_rule(const simple_packet_t& current_packet, const
 
     if (flow_announce.destination_ports.size() == 0) {
         destination_port_matches = true;
-    } else if (is_tcp_or_udp) {
+    } else if (port_component_applies) {
         if (std::find(flow_announce.destination_ports.begin(), flow_announce.destination_ports.end(),
                       current_packet.destination_port) != flow_announce.destination_ports.end()) {
             // We found this IP in list
@@ -57,7 +59,7 @@ bool filter_packet_by_flowspec_rule(const simple_packet_t& current_packet, const
 
     if (flow_announce.ports.size() == 0) {
         port_matches = true;
-    } else if (is_tcp_or_udp &&
+    } else if (port_component_applies &&
                (std::find(flow_announce.ports.begin(), flow_announce.ports.end(), current_packet.source_port) !=
                     flow_announce.ports.end() ||
                 std::find(flow_announce.ports.begin(), flow_announce.ports.end(), current_packet.destination_port) !=

--- a/src/filter.cpp
+++ b/src/filter.cpp
@@ -29,10 +29,11 @@ bool filter_packet_by_flowspec_rule(const simple_packet_t& current_packet, const
     bool tcp_flags_matches           = false;
     bool fragmentation_flags_matches = false;
     bool protocol_matches            = false;
+    const bool is_tcp_or_udp          = current_packet.protocol == IPPROTO_TCP || current_packet.protocol == IPPROTO_UDP;
 
     if (flow_announce.source_ports.size() == 0) {
         source_port_matches = true;
-    } else {
+    } else if (is_tcp_or_udp) {
         if (std::find(flow_announce.source_ports.begin(), flow_announce.source_ports.end(), current_packet.source_port) !=
             flow_announce.source_ports.end()) {
             // We found this IP in list
@@ -42,7 +43,7 @@ bool filter_packet_by_flowspec_rule(const simple_packet_t& current_packet, const
 
     if (flow_announce.destination_ports.size() == 0) {
         destination_port_matches = true;
-    } else {
+    } else if (is_tcp_or_udp) {
         if (std::find(flow_announce.destination_ports.begin(), flow_announce.destination_ports.end(),
                       current_packet.destination_port) != flow_announce.destination_ports.end()) {
             // We found this IP in list
@@ -52,7 +53,7 @@ bool filter_packet_by_flowspec_rule(const simple_packet_t& current_packet, const
 
     if (flow_announce.ports.size() == 0) {
         port_matches = true;
-    } else if ((current_packet.protocol == IPPROTO_TCP || current_packet.protocol == IPPROTO_UDP) &&
+    } else if (is_tcp_or_udp &&
                (std::find(flow_announce.ports.begin(), flow_announce.ports.end(), current_packet.source_port) !=
                     flow_announce.ports.end() ||
                 std::find(flow_announce.ports.begin(), flow_announce.ports.end(), current_packet.destination_port) !=

--- a/src/netflow_plugin/ipfix.hpp
+++ b/src/netflow_plugin/ipfix.hpp
@@ -38,6 +38,10 @@
 #define IPFIX_IPV6_SRC_MASK 29
 #define IPFIX_IPV6_DST_MASK 30
 
+// IANA IE 32 is icmpTypeCodeIPv4: a two-octet combined value encoded as
+// type * 256 + code, so the type and code are the first and second wire bytes.
+#define IPFIX_ICMP_TYPE_CODE_IPV4 32
+
 // RFC claims that this field is deprecated in favour of IPFIX_SAMPLING_PACKET_INTERVAL but many vendors use it, we need to support it too
 #define IPFIX_SAMPLING_INTERVAL 34
 
@@ -66,6 +70,10 @@
 
 #define IPFIX_FLOW_END_REASON 136
 
+// IANA IE 139 is the IPv6 counterpart, icmpTypeCodeIPv6, with the same
+// two-octet type-then-code wire encoding as IE 32.
+#define IPFIX_ICMP_TYPE_CODE_IPV6 139
+
 // We use 8 byte encoding for "dateTimeMilliseconds" https://tools.ietf.org/html/rfc7011#page-35
 #define IPFIX_FLOW_START_MILLISECONDS 152
 #define IPFIX_FLOW_END_MILLISECONDS 153
@@ -73,6 +81,14 @@
 // We use 8 byte encoding: https://datatracker.ietf.org/doc/html/rfc7011#section-6.1.10
 #define IPFIX_FLOW_START_NANOSECONDS 156
 #define IPFIX_FLOW_END_NANOSECONDS 157
+
+// IANA IEs 176-179 are the alternative separate one-octet ICMP fields.
+// Accept both variants; the collector gives these dedicated fields (and the
+// combined fields above) precedence over destination-port overloading.
+#define IPFIX_ICMP_TYPE_IPV4 176
+#define IPFIX_ICMP_CODE_IPV4 177
+#define IPFIX_ICMP_TYPE_IPV6 178
+#define IPFIX_ICMP_CODE_IPV6 179
 
 // UDP ports
 #define IPFIX_UDP_SOURCE_PORT 180

--- a/src/netflow_plugin/ipfix_collector.cpp
+++ b/src/netflow_plugin/ipfix_collector.cpp
@@ -1,3 +1,4 @@
+#include <algorithm>
 #include <cstdint>
 #include <fstream>
 #include <string>
@@ -877,6 +878,38 @@ bool ipfix_record_to_flow(uint32_t record_type, uint32_t record_length, const ui
             packet.destination_port = fast_ntoh(packet.destination_port);
         }
 
+        break;
+    case IPFIX_ICMP_TYPE_CODE_IPV4:
+    case IPFIX_ICMP_TYPE_CODE_IPV6:
+        // IEs 32 and 139 are the combined IPv4/IPv6 variants: two bytes with
+        // type followed by code. Reading bytes avoids alignment and host-endian
+        // assumptions.
+        if (record_length == 2) {
+            packet.icmp_type     = data[0];
+            packet.icmp_code     = data[1];
+            packet.icmp_type_set = true;
+            packet.icmp_code_set = true;
+        } else {
+            ipfix_too_large_field++;
+        }
+        break;
+    case IPFIX_ICMP_TYPE_IPV4:
+    case IPFIX_ICMP_TYPE_IPV6:
+        if (record_length == 1) {
+            packet.icmp_type     = data[0];
+            packet.icmp_type_set = true;
+        } else {
+            ipfix_too_large_field++;
+        }
+        break;
+    case IPFIX_ICMP_CODE_IPV4:
+    case IPFIX_ICMP_CODE_IPV6:
+        if (record_length == 1) {
+            packet.icmp_code     = data[0];
+            packet.icmp_code_set = true;
+        } else {
+            ipfix_too_large_field++;
+        }
         break;
     case IPFIX_TCP_SOURCE_PORT:
         // This is unusual encoding used only by AMD Pensando
@@ -2032,6 +2065,27 @@ bool ipfix_data_set_to_store(const uint8_t* packet_ptr,
 
     // Logical sources of this logic are unknown but I'm sure we had reasons to do so
     if (packet.protocol == IPPROTO_ICMP) {
+        const bool destination_port_was_exported =
+            std::any_of(field_template->records.begin(), field_template->records.end(), [](const template_record_t& record) {
+                return record.record_type == IPFIX_L4_DST_PORT;
+            });
+
+        // Some IPFIX exporters retain the NetFlow convention of encoding ICMP
+        // as type << 8 | code in destination port. Use that fallback only when
+        // the template actually contains field 11, and never overwrite the
+        // standardized ICMP information elements decoded above.
+        if (destination_port_was_exported) {
+            if (!packet.icmp_type_set) {
+                packet.icmp_type     = uint8_t(packet.destination_port >> 8);
+                packet.icmp_type_set = true;
+            }
+
+            if (!packet.icmp_code_set) {
+                packet.icmp_code     = uint8_t(packet.destination_port & 0xff);
+                packet.icmp_code_set = true;
+            }
+        }
+
         // Explicitly set ports to zeros even if device sent something in these fields
         packet.source_port      = 0;
         packet.destination_port = 0;

--- a/src/netflow_plugin/netflow_collector.cpp
+++ b/src/netflow_plugin/netflow_collector.cpp
@@ -253,6 +253,13 @@ void override_packet_fields_from_nested_packet(simple_packet_t& packet, const si
     packet.source_port      = nested_packet.source_port;
     packet.destination_port = nested_packet.destination_port;
 
+    // The embedded packet parser has authoritative ICMP metadata. Preserve its
+    // presence flags as zero is a valid type and code, not a missing sentinel.
+    packet.icmp_type     = nested_packet.icmp_type;
+    packet.icmp_code     = nested_packet.icmp_code;
+    packet.icmp_type_set = nested_packet.icmp_type_set;
+    packet.icmp_code_set = nested_packet.icmp_code_set;
+
     packet.protocol          = nested_packet.protocol;
     packet.length            = nested_packet.length;
     packet.ip_length         = nested_packet.ip_length;

--- a/src/netflow_plugin/netflow_v5_collector.cpp
+++ b/src/netflow_plugin/netflow_v5_collector.cpp
@@ -175,6 +175,13 @@ bool process_netflow_packet_v5(const uint8_t* packet,
         case 1: {
             // ICMP
             current_packet.protocol = IPPROTO_ICMP;
+
+            // NetFlow v5 stores ICMP type and code in the destination-port
+            // field as type << 8 | code.
+            current_packet.icmp_type = uint8_t(current_packet.destination_port >> 8);
+            current_packet.icmp_code = uint8_t(current_packet.destination_port & 0xff);
+            current_packet.icmp_type_set = true;
+            current_packet.icmp_code_set = true;
         } break;
 
         case 6: {
@@ -197,5 +204,3 @@ bool process_netflow_packet_v5(const uint8_t* packet,
 
     return true;
 }
-
-

--- a/src/netflow_plugin/netflow_v9.hpp
+++ b/src/netflow_plugin/netflow_v9.hpp
@@ -31,6 +31,12 @@
 #define NETFLOW9_IPV6_DST_ADDR 28
 #define NETFLOW9_IPV6_SRC_MASK 29
 #define NETFLOW9_IPV6_DST_MASK 30
+
+// ICMP has several export encodings in the wild. IANA IPFIX IE 32
+// (icmpTypeCodeIPv4) and IE 139 (icmpTypeCodeIPv6) are two-octet combined
+// values encoded as type * 256 + code, i.e. type is the first wire byte.
+// Flexible NetFlow v9 exporters commonly reuse these IPFIX element numbers.
+#define NETFLOW9_ICMP_TYPE_CODE_IPV4 32
 // Juniper MX things,
 // http://www.juniper.net/techpubs/en_US/junos/topics/task/configuration/flow-aggregation-template-id-configuring-version9-ipfix.html
 #define NETFLOW9_SAMPLING_INTERVAL 34
@@ -74,7 +80,17 @@
 
 #define NETFLOW9_LAYER2_PACKET_SECTION_DATA 104
 
+#define NETFLOW9_ICMP_TYPE_CODE_IPV6 139
+
 #define NETFLOW9_FLOW_ID 148
+
+// IANA IEs 176-179 carry type and code as separate one-octet fields. Support
+// both the combined and separate variants; collectors prefer either dedicated
+// representation over the legacy destination-port overload.
+#define NETFLOW9_ICMP_TYPE_IPV4 176
+#define NETFLOW9_ICMP_CODE_IPV4 177
+#define NETFLOW9_ICMP_TYPE_IPV6 178
+#define NETFLOW9_ICMP_CODE_IPV6 179
 
 // Cisco calls them "timestamp absolute first" and "timestamp absolute last"
 #define NETFLOW9_START_MILLISECONDS 152

--- a/src/netflow_plugin/netflow_v9_collector.cpp
+++ b/src/netflow_plugin/netflow_v9_collector.cpp
@@ -1,5 +1,6 @@
 #include "netflow_v9_collector.hpp"
 
+#include <algorithm>
 #include <cstdint>
 #include <fstream>
 #include <string>
@@ -581,6 +582,38 @@ bool netflow9_record_to_flow(uint32_t record_type,
             packet.destination_port = fast_ntoh(packet.destination_port);
         }
 
+        break;
+    case NETFLOW9_ICMP_TYPE_CODE_IPV4:
+    case NETFLOW9_ICMP_TYPE_CODE_IPV6:
+        // IEs 32 and 139 are the combined IPv4/IPv6 variants. IANA defines
+        // their network-order value as type * 256 + code. Decode bytes directly
+        // so the meaning is independent of host endianness.
+        if (record_length == 2) {
+            packet.icmp_type     = data[0];
+            packet.icmp_code     = data[1];
+            packet.icmp_type_set = true;
+            packet.icmp_code_set = true;
+        } else {
+            netflow_v9_too_large_field++;
+        }
+        break;
+    case NETFLOW9_ICMP_TYPE_IPV4:
+    case NETFLOW9_ICMP_TYPE_IPV6:
+        if (record_length == 1) {
+            packet.icmp_type     = data[0];
+            packet.icmp_type_set = true;
+        } else {
+            netflow_v9_too_large_field++;
+        }
+        break;
+    case NETFLOW9_ICMP_CODE_IPV4:
+    case NETFLOW9_ICMP_CODE_IPV6:
+        if (record_length == 1) {
+            packet.icmp_code     = data[0];
+            packet.icmp_code_set = true;
+        } else {
+            netflow_v9_too_large_field++;
+        }
         break;
     case NETFLOW9_IPV4_SRC_ADDR:
         if (record_length > sizeof(packet.src_ip)) {
@@ -1711,6 +1744,27 @@ void netflow9_flowset_to_store(const uint8_t* pkt,
 
     // Logical sources of this logic are unknown but I'm sure we had reasons to do so
     if (packet.protocol == IPPROTO_ICMP) {
+        const bool destination_port_was_exported =
+            std::any_of(template_records.begin(), template_records.end(), [](const template_record_t& record) {
+                return record.record_type == NETFLOW9_L4_DST_PORT;
+            });
+
+        // Many NetFlow exporters overload destination port for ICMP as
+        // type << 8 | code. Only use it when field 11 was present in the
+        // template; a default zero must not be mistaken for echo reply.
+        // Dedicated ICMP fields, when exported, remain authoritative.
+        if (destination_port_was_exported) {
+            if (!packet.icmp_type_set) {
+                packet.icmp_type     = uint8_t(packet.destination_port >> 8);
+                packet.icmp_type_set = true;
+            }
+
+            if (!packet.icmp_code_set) {
+                packet.icmp_code     = uint8_t(packet.destination_port & 0xff);
+                packet.icmp_code_set = true;
+            }
+        }
+
         // Explicitly set ports to zeros even if device sent something in these fields
         packet.source_port      = 0;
         packet.destination_port = 0;

--- a/src/simple_packet_parser_ng.cpp
+++ b/src/simple_packet_parser_ng.cpp
@@ -280,6 +280,8 @@ parser_code_t parse_raw_packet_to_simple_packet_full(const uint8_t* pointer,
 
         packet.icmp_type = icmp_header->get_type();
         packet.icmp_code = icmp_header->get_code();
+        packet.icmp_type_set = true;
+        packet.icmp_code_set = true;
     } else if (protocol == IpProtocolNumberIPV6_ICMP) {
         // Please note that IPv4 and IPv6 ICMP are different protocols
         // and we handle only IPv6 ICMP here which has same type and code fields as IPv4 ICMP
@@ -291,6 +293,8 @@ parser_code_t parse_raw_packet_to_simple_packet_full(const uint8_t* pointer,
 
         packet.icmp_type = icmp_header->get_type();
         packet.icmp_code = icmp_header->get_code();
+        packet.icmp_type_set = true;
+        packet.icmp_code_set = true;
     } else if (protocol == IpProtocolNumberUDP) {
         if (local_pointer + sizeof(udp_header_t) > end_pointer) {
             return parser_code_t::memory_violation;
@@ -445,6 +449,8 @@ parser_code_t parse_raw_ipv6_packet_to_simple_packet_full(const uint8_t* pointer
 
         packet.icmp_type = icmp_header->get_type();
         packet.icmp_code = icmp_header->get_code();
+        packet.icmp_type_set = true;
+        packet.icmp_code_set = true;
     } else {
         // That's fine, it's not some known protocol but we can export basic information retrieved from IP packet
         return parser_code_t::success;
@@ -556,6 +562,8 @@ parser_code_t parse_raw_ipv4_packet_to_simple_packet_full(const uint8_t* pointer
 
         packet.icmp_type = icmp_header->get_type();
         packet.icmp_code = icmp_header->get_code();
+        packet.icmp_type_set = true;
+        packet.icmp_code_set = true;
     } else {
         // That's fine, it's not some known protocol but we can export basic information retrieved from IP packet
         return parser_code_t::success;

--- a/src/simple_packet_parser_ng.cpp
+++ b/src/simple_packet_parser_ng.cpp
@@ -267,7 +267,9 @@ parser_code_t parse_raw_packet_to_simple_packet_full(const uint8_t* pointer,
 
         // TODO: rework this code to use structs with bit fields
         packet.flags = tcp_header->get_fin() * 0x01 + tcp_header->get_syn() * 0x02 + tcp_header->get_rst() * 0x04 +
-                       tcp_header->get_psh() * 0x08 + tcp_header->get_ack() * 0x10 + tcp_header->get_urg() * 0x20;
+                       tcp_header->get_psh() * 0x08 + tcp_header->get_ack() * 0x10 + tcp_header->get_urg() * 0x20 +
+                       tcp_header->get_ece() * 0x40 + tcp_header->get_cwr() * 0x80;
+        packet.tcp_ns = tcp_header->get_ns();
 
     } else if (protocol == IpProtocolNumberICMP) {
         // Please note that IPv4 and IPv6 ICMP are different protocols
@@ -421,7 +423,9 @@ parser_code_t parse_raw_ipv6_packet_to_simple_packet_full(const uint8_t* pointer
 
         // TODO: rework this code to use structs with bit fields
         packet.flags = tcp_header->get_fin() * 0x01 + tcp_header->get_syn() * 0x02 + tcp_header->get_rst() * 0x04 +
-                       tcp_header->get_psh() * 0x08 + tcp_header->get_ack() * 0x10 + tcp_header->get_urg() * 0x20;
+                       tcp_header->get_psh() * 0x08 + tcp_header->get_ack() * 0x10 + tcp_header->get_urg() * 0x20 +
+                       tcp_header->get_ece() * 0x40 + tcp_header->get_cwr() * 0x80;
+        packet.tcp_ns = tcp_header->get_ns();
 
         packet.tcp_sequence_number = tcp_header->get_sequence_number_host_byte_order();
         packet.tcp_ack_number      = tcp_header->get_ack_number_host_byte_order();
@@ -534,7 +538,9 @@ parser_code_t parse_raw_ipv4_packet_to_simple_packet_full(const uint8_t* pointer
 
         // TODO: rework this code to use structs with bit fields
         packet.flags = tcp_header->get_fin() * 0x01 + tcp_header->get_syn() * 0x02 + tcp_header->get_rst() * 0x04 +
-                       tcp_header->get_psh() * 0x08 + tcp_header->get_ack() * 0x10 + tcp_header->get_urg() * 0x20;
+                       tcp_header->get_psh() * 0x08 + tcp_header->get_ack() * 0x10 + tcp_header->get_urg() * 0x20 +
+                       tcp_header->get_ece() * 0x40 + tcp_header->get_cwr() * 0x80;
+        packet.tcp_ns = tcp_header->get_ns();
 
         packet.tcp_sequence_number = tcp_header->get_sequence_number_host_byte_order();
         packet.tcp_ack_number      = tcp_header->get_ack_number_host_byte_order();


### PR DESCRIPTION
This commits bring improved conformance with RFC8955, including some corner cases (like validating ports without verifying if it is UDP/TCP protocol).
The new generic-port, ICMP type/code, tcp flags ECE/CWR, two-octet TCP-mask, and large component-payload cases passes now mrtgen tests.
